### PR TITLE
fix: clean CLAUDE env vars on daemon startup

### DIFF
--- a/crates/airlock-daemon/src/main.rs
+++ b/crates/airlock-daemon/src/main.rs
@@ -26,6 +26,18 @@ async fn main() -> Result<()> {
         .with_target(true)
         .init();
 
+    // Clean environment variables that would interfere with child processes
+    // (e.g. when the daemon is started from within a Claude Code session).
+    for key in [
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CLAUDE_CODE_ENTRY_POINT",
+        "CLAUDE_CODE_SESSION_ID",
+        "CLAUDE_CODE_SESSION_ACCESS_TOKEN",
+    ] {
+        std::env::remove_var(key);
+    }
+
     info!("Starting Airlock daemon...");
 
     // Ensure Airlock directories exist


### PR DESCRIPTION
## Summary
- When the daemon is started from within a Claude Code session, it inherits `CLAUDECODE` and related env vars
- Child processes (like `airlock exec agent`) detect a nested session and refuse to run with: "Claude Code cannot be launched inside another Claude Code session"
- Strip these env vars early in `main()` so they never leak to pipeline stages