### PR TITLE
feat(stage-log-viewer): surface step errors

### DIFF
--- a/crates/airlock-app/src/components/StageLogViewer/StageLogViewer.tsx
+++ b/crates/airlock-app/src/components/StageLogViewer/StageLogViewer.tsx
@@ -41,8 +41,9 @@ function TabIcon({ item }: { item: TabItem }) {
 }
 
 /**
- * StageLogViewer displays logs (stdout/stderr) for a pipeline step.
- * Uses a tabbed interface to switch between different outputs.
+ * StageLogViewer displays step output in tabs (stdout/stderr plus step artifacts).
+ * Shows the step failure message when `step.error` is present, including failed
+ * steps that produced no log files.
  * Supports real-time updates for running steps.
  */
 export function StageLogViewer({ step, jobKey, repoId, runId, artifacts = [] }: StageLogViewerProps) {


### PR DESCRIPTION
## Summary
The stage log viewer now shows explicit `step.error` failure details so users can diagnose failed stages even when `stdout`/`stderr` logs are empty, instead of seeing only a generic no-logs message.

## Key changes made
- Updated `StageLogViewer` to render a failed-step empty state card when no logs/artifacts are available but `step.error` exists.
- Added an inline error banner in the tabbed log/artifact view when `step.error` is present.
- Updated `use-stage-log` browser mock data and run-detail fixture data to include a failed `rebase` step with an error message for error-only failure coverage.

## How was this tested
- `cargo test -p airlock-app`
- `cargo test --workspace --exclude airlock-app` (initially hit an unrelated default-branch assumption in one baseline test)
- `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master cargo test --workspace --exclude airlock-app`
- Targeted integration tests:
  - `cargo test -p airlock-cli --test e2e_stage_pipeline test_step_result_error_field -- --test-threads=1`
  - `cargo test -p airlock-cli --test e2e_stage_pipeline test_daemon_restart_marks_running_step_as_failed -- --test-threads=1`
  - `cargo test -p airlock-cli --test daemon_commands test_e2e_get_run_detail_returns_valid_shared_types -- --test-threads=1`
