### PR TITLE
fix(window-resize): smooth out window launch

### DIFF
--- a/crates/airlock-app/src-tauri/src/lib.rs
+++ b/crates/airlock-app/src-tauri/src/lib.rs
@@ -382,6 +382,16 @@ async fn read_artifact(
     }
 }
 
+/// Show the main window. Called by the frontend once it has mounted,
+/// ensuring the window-state plugin has already restored geometry.
+#[tauri::command]
+async fn show_window(app: tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
 // =============================================================================
 // Application Entry Point
 // =============================================================================
@@ -401,7 +411,14 @@ pub fn run() {
                 let _ = window.set_focus();
             }
         }))
-        .plugin(tauri_plugin_window_state::Builder::new().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::new()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::all()
+                        & !tauri_plugin_window_state::StateFlags::VISIBLE,
+                )
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(
@@ -476,10 +493,10 @@ pub fn run() {
                 event_bridge::run_event_bridge(app_handle).await;
             });
 
-            // Focus the window on initial launch
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.set_focus();
-            }
+            // Window stays hidden until the frontend calls show_window.
+            // By that point the window-state plugin has already restored
+            // size/position/maximized, so the window appears in its final
+            // state with no resize flicker.
 
             Ok(())
         })
@@ -515,6 +532,7 @@ pub fn run() {
             update_config,
             read_artifact,
             apply_patches,
+            show_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/crates/airlock-app/src-tauri/tauri.conf.json
+++ b/crates/airlock-app/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "minHeight": 600,
         "resizable": true,
         "fullscreen": false,
-        "maximized": true
+        "maximized": true,
+        "visible": false
       }
     ],
     "security": {

--- a/crates/airlock-app/src/lib/tauri.ts
+++ b/crates/airlock-app/src/lib/tauri.ts
@@ -162,6 +162,9 @@ async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
       return mockData.readArtifact(artifactPath) as T;
     }
 
+    case 'show_window':
+      return undefined as T;
+
     default:
       throw new Error(`Unknown command: ${cmd}`);
   }

--- a/crates/airlock-app/src/main.tsx
+++ b/crates/airlock-app/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
+import { invoke } from './lib/tauri';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -11,3 +12,7 @@ createRoot(document.getElementById('root')!).render(
     </BrowserRouter>
   </StrictMode>
 );
+
+// Reveal the window now that the frontend has mounted and the
+// window-state plugin has finished restoring geometry.
+invoke('show_window').catch(() => {});


### PR DESCRIPTION
## Summary
This change removes startup window resize flicker by launching the Tauri window hidden and showing it only after the React UI mounts and window state restoration is complete.

## Key changes made
- Set the Tauri main window to launch hidden (`visible: false`).
- Updated window-state restoration flags to restore geometry without restoring visibility.
- Added a new backend Tauri command, `show_window`, to show and focus the `main` window.
- Registered `show_window` in the invoke handler and updated frontend startup to call `invoke('show_window')` after mount.
- Added mock-mode support for `show_window` in the frontend Tauri wrapper.

## How was this tested
- `cargo test -p airlock-app`
- `cargo test -p airlock-app --test e2e_performance -- --nocapture`
- `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master cargo test --workspace --exclude airlock-app`
- Lint/format checks passed for changed files (`make check` equivalent pipeline checks)
