### PR TITLE
fix: show banner only for run-creating pushes

### DIFF
--- a/crates/airlock-cli/src/commands/init_tests.rs
+++ b/crates/airlock-cli/src/commands/init_tests.rs
@@ -551,7 +551,7 @@ fn test_init_installs_post_receive_hook_in_bare_repo() {
     assert!(post_receive_path.exists());
 
     let hook_content = fs::read_to_string(&post_receive_path).unwrap();
-    assert_eq!(hook_content, git::hooks::POST_RECEIVE);
+    assert_eq!(hook_content, git::hooks::post_receive_hook());
     assert!(hook_content.starts_with("#!/bin/sh"));
     assert!(hook_content.contains("SOCKET="));
     assert!(hook_content.contains("push_received"));

--- a/crates/airlock-core/src/git/hooks.rs
+++ b/crates/airlock-core/src/git/hooks.rs
@@ -8,95 +8,101 @@ use std::path::Path;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-/// Build the pre-receive hook script, embedding `crate::BANNER`.
+/// Build the pre-receive hook script.
 ///
-/// The banner is displayed in the brand signal color (ANSI 256-color 98, orbital violet)
-/// when stderr is a terminal and `NO_COLOR` is not set.
+/// The pre-receive hook silently accepts all pushes. All user-visible output
+/// is deferred to the post-receive hook, which conditionally displays the
+/// banner based on whether the daemon will create a pipeline run.
 pub fn pre_receive_hook() -> String {
-    format!(
-        r#"#!/bin/sh
-# Airlock pre-receive hook
-# Accepts pushes locally and displays push info.
-
-# Use brand color (signal violet) when stderr is a terminal and NO_COLOR is unset
-if [ -t 2 ] && [ -z "${{NO_COLOR:-}}" ]; then
-    BRAND='\033[1;38;5;{color}m'
-    RESET='\033[0m'
-else
-    BRAND=''
-    RESET=''
-fi
-
-printf "${{BRAND}}" >&2
-cat >&2 <<'BANNER'
-{}BANNER
-printf "${{RESET}}" >&2
-
-echo "" >&2
-
-while read oldrev newrev refname; do
-    branch="${{refname#refs/heads/}}"
-    if [ "$oldrev" = "0000000000000000000000000000000000000000" ]; then
-        echo "${{branch}} (new branch)" >&2
-    elif [ "$newrev" = "0000000000000000000000000000000000000000" ]; then
-        echo "${{branch}} (delete)" >&2
-    else
-        short_old=$(echo "$oldrev" | cut -c1-7)
-        short_new=$(echo "$newrev" | cut -c1-7)
-        echo "${{branch}} (${{short_old}}..${{short_new}})" >&2
-    fi
-done
-
-echo "" >&2
-
-# Always accept the push (soft gate)
-exit 0
-"#,
-        crate::BANNER,
-        color = crate::BRAND_COLOR_256,
-    )
+    "#!/bin/sh\n# Airlock pre-receive hook\nexit 0\n".to_string()
 }
 
-/// Post-receive hook script.
-/// This hook triggers the transformation pipeline after push is accepted.
-pub const POST_RECEIVE: &str = r#"#!/bin/sh
+/// Build the post-receive hook script, embedding `crate::BANNER`.
+///
+/// The post-receive hook sends a synchronous JSON-RPC request to the daemon
+/// and conditionally displays the banner + branch info based on whether
+/// the daemon will create a pipeline run.
+pub fn post_receive_hook() -> String {
+    format!(
+        r#"#!/bin/sh
 # Airlock post-receive hook
 # Triggers the transformation pipeline after a push is accepted.
 
-SOCKET="${HOME}/.airlock/socket"
+SOCKET="${{HOME}}/.airlock/socket"
 REPO_PATH="$(pwd)"
 
-# Collect all ref updates and create push marker refs
+# Collect all ref updates, create push marker refs, and build display info
 REF_UPDATES=""
+DISPLAY_INFO=""
 while read oldrev newrev refname; do
     if [ -n "$REF_UPDATES" ]; then
-        REF_UPDATES="${REF_UPDATES},"
+        REF_UPDATES="${{REF_UPDATES}},"
     fi
-    REF_UPDATES="${REF_UPDATES}{\"ref_name\":\"${refname}\",\"old_sha\":\"${oldrev}\",\"new_sha\":\"${newrev}\"}"
+    REF_UPDATES="${{REF_UPDATES}}{{\"ref_name\":\"${{refname}}\",\"old_sha\":\"${{oldrev}}\",\"new_sha\":\"${{newrev}}\"}}"
 
     # Create marker ref for pipeline branches (non-deletion pushes to refs/heads/*)
     case "$refname" in
         refs/heads/*)
             if [ "$newrev" != "0000000000000000000000000000000000000000" ]; then
-                branch="${refname#refs/heads/}"
-                git update-ref "refs/airlock/pushed/${branch}" "$newrev" 2>/dev/null || true
+                branch="${{refname#refs/heads/}}"
+                git update-ref "refs/airlock/pushed/${{branch}}" "$newrev" 2>/dev/null || true
             fi
             ;;
     esac
+
+    # Build display info for branch updates
+    branch="${{refname#refs/heads/}}"
+    if [ "$oldrev" = "0000000000000000000000000000000000000000" ]; then
+        DISPLAY_INFO="${{DISPLAY_INFO}}${{branch}} (new branch)
+"
+    elif [ "$newrev" = "0000000000000000000000000000000000000000" ]; then
+        DISPLAY_INFO="${{DISPLAY_INFO}}${{branch}} (delete)
+"
+    else
+        short_old=$(echo "$oldrev" | cut -c1-7)
+        short_new=$(echo "$newrev" | cut -c1-7)
+        DISPLAY_INFO="${{DISPLAY_INFO}}${{branch}} (${{short_old}}..${{short_new}})
+"
+    fi
 done
 
-# Notify daemon of push received
+# Notify daemon and check if runs will be created
 if [ -S "$SOCKET" ]; then
-    echo "{\"jsonrpc\":\"2.0\",\"method\":\"push_received\",\"params\":{\"gate_path\":\"${REPO_PATH}\",\"ref_updates\":[${REF_UPDATES}]},\"id\":null}" | nc -U "$SOCKET" > /dev/null 2>&1 &
-    echo "A new change has entered Airlock. Track it in the Airlock app." >&2
+    RESPONSE=$(echo "{{\"jsonrpc\":\"2.0\",\"method\":\"push_received\",\"params\":{{\"gate_path\":\"${{REPO_PATH}}\",\"ref_updates\":[${{REF_UPDATES}}]}},\"id\":1}}" | nc -U "$SOCKET" 2>/dev/null)
+
+    if echo "$RESPONSE" | grep -q '"will_create_run":true'; then
+        # Use brand color (signal violet) when stderr is a terminal and NO_COLOR is unset
+        if [ -t 2 ] && [ -z "${{NO_COLOR:-}}" ]; then
+            BRAND='\033[1;38;5;{color}m'
+            RESET='\033[0m'
+        else
+            BRAND=''
+            RESET=''
+        fi
+
+        printf "${{BRAND}}" >&2
+        cat >&2 <<'BANNER'
+{banner}BANNER
+        printf "${{RESET}}" >&2
+
+        echo "" >&2
+        printf "%s" "$DISPLAY_INFO" >&2
+        echo "" >&2
+        echo "A new change has entered Airlock. Track it in the Airlock app." >&2
+        echo "" >&2
+    fi
 else
     echo "! Daemon is not running" >&2
     echo "Run 'airlock daemon start' to process this push." >&2
+    echo "" >&2
 fi
 
-echo "" >&2
 exit 0
-"#;
+"#,
+        banner = crate::BANNER,
+        color = crate::BRAND_COLOR_256,
+    )
+}
 
 /// Upload-pack wrapper script content.
 ///
@@ -160,7 +166,7 @@ pub fn install_hooks(repo_path: &Path) -> Result<()> {
 
     // Install post-receive hook
     let post_receive_path = hooks_dir.join("post-receive");
-    fs::write(&post_receive_path, POST_RECEIVE)?;
+    fs::write(&post_receive_path, post_receive_hook())?;
     make_executable(&post_receive_path)?;
     tracing::debug!(
         "Installed post-receive hook at {}",

--- a/crates/airlock-core/src/git/mod.rs
+++ b/crates/airlock-core/src/git/mod.rs
@@ -30,8 +30,8 @@ pub use fetch::{
     BranchSyncStatus, ConflictResolver, SyncReport,
 };
 pub use hooks::{
-    configure_upload_pack, install_hooks, install_upload_pack_wrapper, pre_receive_hook,
-    remove_hooks, POST_RECEIVE, UPLOAD_PACK_WRAPPER,
+    configure_upload_pack, install_hooks, install_upload_pack_wrapper, post_receive_hook,
+    pre_receive_hook, remove_hooks, UPLOAD_PACK_WRAPPER,
 };
 pub use push::{
     build_refspec, push, push_all_branches, push_branch, push_force_with_lease, push_ref_updates,

--- a/crates/airlock-core/src/git/tests.rs
+++ b/crates/airlock-core/src/git/tests.rs
@@ -576,23 +576,16 @@ fn test_pre_receive_hook_logs_ref_updates_to_stderr() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // 5. Verify stderr contains the banner from pre-receive hook
+    // 5. Verify stderr does NOT contain the banner (pre-receive is now silent)
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("▗▄▖"),
-        "Pre-receive hook should display Airlock banner. Got: {}",
-        stderr
-    );
-
-    // 6. Verify the branch info is shown
-    assert!(
-        stderr.contains("master"),
-        "Pre-receive hook should display branch name. Got: {}",
+        !stderr.contains("▗▄▖"),
+        "Pre-receive hook should NOT display Airlock banner (output moved to post-receive). Got: {}",
         stderr
     );
 }
 
-/// Test that the pre-receive hook script content has the expected format.
+/// Test that the pre-receive hook script is a minimal accept-all script.
 #[test]
 fn test_pre_receive_hook_content_format() {
     let hook = pre_receive_hook();
@@ -600,25 +593,17 @@ fn test_pre_receive_hook_content_format() {
     // Verify hook is a shell script
     assert!(hook.starts_with("#!/bin/sh"));
 
-    // Verify hook reads from stdin (the standard git hook protocol)
-    assert!(hook.contains("while read oldrev newrev refname"));
-
-    // Verify hook displays branch info to stderr
-    assert!(
-        hook.contains(r#"branch="${refname#refs/heads/}""#),
-        "Pre-receive hook should extract branch name from refname"
-    );
-
-    // Verify hook always exits 0 (soft gate - accepts all pushes)
+    // Verify hook always exits 0 (accepts all pushes)
     assert!(hook.contains("exit 0"));
 
-    // Verify the comment explains it's a soft gate
-    assert!(hook.contains("Always accept the push"));
-
-    // Verify the banner is embedded from the shared constant
+    // Pre-receive hook should be silent — no banner, no branch info
     assert!(
-        hook.contains("▗▄▖"),
-        "Pre-receive hook should contain the BANNER text"
+        !hook.contains("▗▄▖"),
+        "Pre-receive hook should not contain the BANNER text (moved to post-receive)"
+    );
+    assert!(
+        !hook.contains("while read"),
+        "Pre-receive hook should not read stdin (output moved to post-receive)"
     );
 }
 
@@ -653,114 +638,127 @@ fn test_pre_receive_hook_does_not_notify_daemon() {
 fn test_post_receive_hook_notifies_daemon() {
     // Post-receive hook SHOULD contain socket communication
     assert!(
-        POST_RECEIVE.contains("nc -U"),
+        post_receive_hook().contains("nc -U"),
         "Post-receive hook should notify daemon via socket"
     );
     assert!(
-        POST_RECEIVE.contains("SOCKET="),
+        post_receive_hook().contains("SOCKET="),
         "Post-receive hook should have SOCKET variable"
     );
     assert!(
-        POST_RECEIVE.contains("push_received"),
+        post_receive_hook().contains("push_received"),
         "Post-receive hook should send push_received notification"
     );
     assert!(
-        POST_RECEIVE.contains("jsonrpc"),
+        post_receive_hook().contains("jsonrpc"),
         "Post-receive hook should send JSON-RPC messages"
     );
 }
 
-/// Test that post-receive hook content has correct JSON-RPC notification format.
+/// Test that post-receive hook content has correct JSON-RPC request format.
 ///
 /// This test verifies the post-receive hook script structure:
 /// 1. Collects all ref updates from stdin
-/// 2. Constructs a JSON-RPC push_received notification
-/// 3. Sends it to the daemon socket (fire and forget)
+/// 2. Constructs a JSON-RPC push_received request (synchronous, with id)
+/// 3. Sends it to the daemon socket and waits for the response
+/// 4. Conditionally displays banner based on will_create_run in response
 #[test]
 fn test_post_receive_hook_content_format() {
+    let hook = post_receive_hook();
+
     // Verify hook is a shell script
-    assert!(POST_RECEIVE.starts_with("#!/bin/sh"));
+    assert!(hook.starts_with("#!/bin/sh"));
 
     // Verify hook reads from stdin (the standard git hook protocol)
-    assert!(POST_RECEIVE.contains("while read oldrev newrev refname"));
+    assert!(hook.contains("while read oldrev newrev refname"));
 
     // Verify SOCKET is set to the expected path
     assert!(
-        POST_RECEIVE.contains(r#"SOCKET="${HOME}/.airlock/socket""#),
+        hook.contains(r#"SOCKET="${HOME}/.airlock/socket""#),
         "Post-receive hook should use standard socket path"
     );
 
     // Verify REPO_PATH is captured
     assert!(
-        POST_RECEIVE.contains(r#"REPO_PATH="$(pwd)""#),
+        hook.contains(r#"REPO_PATH="$(pwd)""#),
         "Post-receive hook should capture repo path"
     );
 
     // Verify ref updates are collected into JSON array format
-    // The hook uses escaped quotes like \"${refname}\"
     assert!(
-        POST_RECEIVE.contains(r#"\"ref_name\":\"${refname}\""#),
+        hook.contains(r#"\"ref_name\":\"${refname}\""#),
         "Post-receive hook should include ref_name in JSON"
     );
     assert!(
-        POST_RECEIVE.contains(r#"\"old_sha\":\"${oldrev}\""#),
+        hook.contains(r#"\"old_sha\":\"${oldrev}\""#),
         "Post-receive hook should include old_sha in JSON"
     );
     assert!(
-        POST_RECEIVE.contains(r#"\"new_sha\":\"${newrev}\""#),
+        hook.contains(r#"\"new_sha\":\"${newrev}\""#),
         "Post-receive hook should include new_sha in JSON"
     );
 
-    // Verify JSON-RPC notification format with push_received method
-    // The hook uses escaped quotes in the JSON structure
+    // Verify JSON-RPC request format with push_received method
     assert!(
-        POST_RECEIVE.contains(r#"\"method\":\"push_received\""#),
+        hook.contains(r#"\"method\":\"push_received\""#),
         "Post-receive hook should send push_received method"
     );
     assert!(
-        POST_RECEIVE.contains(r#"\"gate_path\":\"${REPO_PATH}\""#),
+        hook.contains(r#"\"gate_path\":\"${REPO_PATH}\""#),
         "Post-receive hook should include gate_path in params"
     );
     assert!(
-        POST_RECEIVE.contains(r#"\"ref_updates\":[${REF_UPDATES}]"#),
+        hook.contains(r#"\"ref_updates\":[${REF_UPDATES}]"#),
         "Post-receive hook should include ref_updates array"
+    );
+
+    // Verify synchronous request pattern (id: 1, captures RESPONSE)
+    assert!(
+        hook.contains(r#"\"id\":1"#),
+        "Post-receive hook should send a request with id (not a notification)"
+    );
+    assert!(
+        hook.contains("RESPONSE=$("),
+        "Post-receive hook should capture daemon response"
+    );
+
+    // Verify conditional output based on will_create_run
+    assert!(
+        hook.contains("will_create_run"),
+        "Post-receive hook should check will_create_run in response"
+    );
+
+    // Verify banner is embedded for conditional display
+    assert!(
+        hook.contains("▗▄▖"),
+        "Post-receive hook should contain the BANNER text"
     );
 
     // Verify socket check before sending
     assert!(
-        POST_RECEIVE.contains(r#"if [ -S "$SOCKET" ]"#),
+        hook.contains(r#"if [ -S "$SOCKET" ]"#),
         "Post-receive hook should check if socket exists"
-    );
-
-    // Verify fire-and-forget pattern (background with &)
-    assert!(
-        POST_RECEIVE.contains("nc -U \"$SOCKET\"") && POST_RECEIVE.contains("&"),
-        "Post-receive hook should send notification in background"
     );
 
     // Verify hook always exits 0
     assert!(
-        POST_RECEIVE.contains("exit 0"),
+        hook.contains("exit 0"),
         "Post-receive hook should always succeed"
     );
 
     // Verify hook has else clause for when daemon is not running
     assert!(
-        POST_RECEIVE.contains("else"),
+        hook.contains("else"),
         "Post-receive hook should have else clause for daemon not running case"
     );
 
     // Verify warning message when daemon is not running
     assert!(
-        POST_RECEIVE.contains("Daemon is not running"),
+        hook.contains("Daemon is not running"),
         "Post-receive hook should warn when daemon is not running"
     );
     assert!(
-        POST_RECEIVE.contains("not running"),
-        "Post-receive hook should explain daemon is not running"
-    );
-    assert!(
-        POST_RECEIVE.contains("airlock daemon start"),
+        hook.contains("airlock daemon start"),
         "Post-receive hook should suggest how to start daemon"
     );
 }

--- a/crates/airlock-daemon/src/handlers/mod.rs
+++ b/crates/airlock-daemon/src/handlers/mod.rs
@@ -93,10 +93,8 @@ pub async fn dispatch(ctx: Arc<HandlerContext>, request: Request) -> Response {
         methods::GET_RUN_DETAIL => runs::handle_get_run_detail(ctx, request.params, id).await,
         methods::MARK_FORWARDED => forward::handle_mark_forwarded(ctx, request.params, id).await,
         methods::PUSH_RECEIVED => {
-            // Push received is a notification (fire and forget), no response needed
-            // But we still process it
-            push::handle_push_received(ctx, request.params).await;
-            Response::success(id, serde_json::json!({"acknowledged": true}))
+            let result = push::handle_push_received(ctx, request.params).await;
+            Response::success(id, serde_json::to_value(result).unwrap())
         }
         methods::FETCH_NOTIFICATION => {
             sync::handle_fetch_notification(ctx, request.params, id).await

--- a/crates/airlock-daemon/src/handlers/push.rs
+++ b/crates/airlock-daemon/src/handlers/push.rs
@@ -13,21 +13,70 @@ use std::path::Path;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
-/// Handle the `push_received` notification (from post-receive hook).
+/// Quick pre-check: will the pushed refs create any pipeline runs?
 ///
-/// This function implements push coalescing and deduplication:
-/// 1. Records the push in the coalescer for debouncing
-/// 2. Checks for ready pushes (debounce period passed)
-/// 3. For each ready push, supersedes overlapping runs and creates a new run
-pub async fn handle_push_received(ctx: Arc<HandlerContext>, params: serde_json::Value) {
-    use crate::ipc::PushReceivedParams;
+/// Partitions refs with `is_pipeline_ref()`, then for each pipeline ref loads
+/// workflows from its tree and filters for the branch. Returns `true` if any
+/// pipeline ref has matching workflows (or would create an error run due to
+/// missing/broken workflows).
+fn check_will_create_runs(gate_path: &Path, ref_updates: &[RefUpdate]) -> bool {
+    let (pipeline_refs, _): (Vec<_>, Vec<_>) =
+        ref_updates.iter().partition(|r| git::is_pipeline_ref(r));
+
+    if pipeline_refs.is_empty() {
+        return false;
+    }
+
+    for update in &pipeline_refs {
+        let branch = match update.ref_name.strip_prefix("refs/heads/") {
+            Some(b) => b,
+            None => continue,
+        };
+
+        match load_workflows_from_tree(gate_path, &update.new_sha) {
+            Ok(all_workflows) if !all_workflows.is_empty() => {
+                let branch_workflows = filter_workflows_for_branch(all_workflows, branch);
+                if !branch_workflows.is_empty() {
+                    return true; // Has matching workflows → will create run
+                }
+                // Has workflows but none match this branch → unmatched, forwarded directly
+            }
+            Ok(_empty) => {
+                // No workflows at all → error run will be created
+                return true;
+            }
+            Err(_) => {
+                // Error loading workflows → error run will be created
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Handle the `push_received` request (from post-receive hook).
+///
+/// This function:
+/// 1. Checks if the push will create any pipeline runs (quick pre-check)
+/// 2. Records the push in the coalescer for debouncing
+/// 3. Checks for ready pushes (debounce period passed)
+/// 4. For each ready push, supersedes overlapping runs and creates a new run
+/// 5. Returns whether the push will create runs (for conditional hook output)
+pub async fn handle_push_received(
+    ctx: Arc<HandlerContext>,
+    params: serde_json::Value,
+) -> crate::ipc::PushReceivedResult {
+    use crate::ipc::{PushReceivedParams, PushReceivedResult};
 
     // Parse parameters
     let params: PushReceivedParams = match serde_json::from_value(params) {
         Ok(p) => p,
         Err(e) => {
             error!("Invalid push_received params: {}", e);
-            return;
+            return PushReceivedResult {
+                will_create_run: false,
+            };
         }
     };
 
@@ -41,7 +90,9 @@ pub async fn handle_push_received(ctx: Arc<HandlerContext>, params: serde_json::
             Ok(r) => r,
             Err(e) => {
                 error!("Failed to list repos: {}", e);
-                return;
+                return PushReceivedResult {
+                    will_create_run: false,
+                };
             }
         };
 
@@ -52,7 +103,9 @@ pub async fn handle_push_received(ctx: Arc<HandlerContext>, params: serde_json::
         Some(r) => r,
         None => {
             error!("No repo found for gate path: {}", params.gate_path);
-            return;
+            return PushReceivedResult {
+                will_create_run: false,
+            };
         }
     };
 
@@ -66,6 +119,9 @@ pub async fn handle_push_received(ctx: Arc<HandlerContext>, params: serde_json::
             new_sha: r.new_sha,
         })
         .collect();
+
+    // Quick pre-check: will this push create any runs?
+    let will_create_run = check_will_create_runs(&repo.gate_path, &ref_updates);
 
     // Record push in coalescer (may return immediately if debounce period passed)
     let ready_refs = ctx
@@ -84,6 +140,8 @@ pub async fn handle_push_received(ctx: Arc<HandlerContext>, params: serde_json::
     for (ready_repo_id, ready_refs) in all_ready {
         process_coalesced_push(ctx.clone(), &ready_repo_id, ready_refs).await;
     }
+
+    PushReceivedResult { will_create_run }
 }
 
 /// Process a coalesced push after the debounce period.

--- a/crates/airlock-daemon/src/ipc.rs
+++ b/crates/airlock-daemon/src/ipc.rs
@@ -579,6 +579,13 @@ pub struct RunDetailInfo {
     pub completed_at: Option<i64>,
 }
 
+/// Result for the `push_received` method.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PushReceivedResult {
+    /// Whether the push will create any pipeline runs.
+    pub will_create_run: bool,
+}
+
 /// Result for the `mark_forwarded` method.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkForwardedResult {


### PR DESCRIPTION
## Summary
Airlock currently prints push-time banner/ref output for every push. This change makes hook output conditional so users only see the banner when the daemon determines the push will create a pipeline run (including error-run cases), keeping non-run pushes quiet.

## Key changes made
- Simplified `pre-receive` to a silent accept-all hook (`exit 0`) and moved user-visible output to conditional post-receive handling.
- Replaced the static `POST_RECEIVE` script constant with generated `post_receive_hook()` output.
- Updated post-receive to send a synchronous `push_received` JSON-RPC request and print banner/ref details only when `will_create_run` is `true`.
- Updated daemon `push_received` handling to return `PushReceivedResult { will_create_run }` with a new `check_will_create_runs` pre-check.
- Updated related tests and docs for the request/response semantics and conditional output behavior.

## How was this tested
- `cargo test -p airlock-core git::tests::`
- `cargo test -p airlock-cli test_init_installs_post_receive_hook_in_bare_repo`
- `cargo test -p airlock-cli test_init_installs_pre_receive_hook_in_bare_repo`
- `cargo test -p airlock-daemon handlers::push::tests::`
- `cargo test -p airlock-daemon ipc::tests::test_parse_push_received_params`
- `cargo test -p airlock-daemon`
- `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master cargo test -p airlock-core`
- `GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=master cargo test -p airlock-cli`
