### PR TITLE
feat: thread diagrams through PR generation

### DIFF
--- a/defaults/create-pr/step.yml
+++ b/defaults/create-pr/step.yml
@@ -62,11 +62,15 @@ run: |
   5. **Return the result** - Provide the PR/MR URL if successful, or explain the error
 
   ## PR/MR Content
-  - Reference artifact content when generating below
+  - Check if \`\$AIRLOCK_ARTIFACTS/description.json\` exists. If it does, use it:
+    - Use the \`title\` field as the PR title
+    - Use the \`body\` field as the basis for the PR description
+    - If a \`mermaid_diagram\` field is present, include it in the PR description as a fenced mermaid code block (\\\`\\\`\\\`mermaid ... \\\`\\\`\\\`)
+  - If description.json does not exist, generate a title and description from the branch name and commit history
   - Do NOT add a signature for who created the PR/MR
-  - The title should be concise and reflect the key change made
-  - The description should have a few concise sections:
+  - The description should have these sections:
     - Summary (of the rationale behind the change)
+    - Diagram (only if a mermaid diagram is available from description.json)
     - Key changes made
     - How was this tested
 

--- a/defaults/describe/step.yml
+++ b/defaults/describe/step.yml
@@ -85,6 +85,15 @@ run: |
   BODY=$(echo "$RESPONSE" | airlock exec json markdown_body)
   DIAGRAM=$(echo "$RESPONSE" | airlock exec json mermaid_diagram)
 
+  # Write description.json for downstream stages (e.g. create-pr)
+  mkdir -p "$AIRLOCK_ARTIFACTS"
+  jq -n \
+    --arg title "$TITLE" \
+    --arg body "$BODY" \
+    --arg diagram "$DIAGRAM" \
+    '{"title": $title, "body": $body, "mermaid_diagram": $diagram, "generated_at": now}' \
+    > "$AIRLOCK_ARTIFACTS/description.json"
+
   # Write as content artifact for display in UI (text summary + mermaid diagram)
   {
     printf "# %s\n\n%s\n\n" "$TITLE" "$BODY"


### PR DESCRIPTION
## Summary
- The describe stage now persists structured PR metadata (`title`, `body`, and `mermaid_diagram`) so downstream stages can reuse generated content instead of regenerating it.
- The create-PR stage now consumes that structured artifact and threads the diagram into PR/MR descriptions.

## Diagram
```mermaid
flowchart TD
  subgraph describe_stage["Describe Stage"]
    direction TB
    describe_step["Describe Step Script (updated)"]:::updated
    structured_output["Structured Summary/Diagram Builder (updated)"]:::updated
    describe_step -->|"calls agent and parses JSON"| structured_output
  end

  subgraph artifacts_stage["Shared Artifacts"]
    direction TB
    description_json["Description JSON Artifact (added)"]:::added
  end

  subgraph create_pr_stage["Create PR Stage"]
    direction TB
    create_pr_step["Create PR Step Script (updated)"]:::updated
    pr_content_builder["PR/MR Content Builder (updated)"]:::updated
    pr_executor["Git Host PR/MR Executor (unchanged)"]:::unchanged
    create_pr_step -->|"builds prompt and instructions"| pr_content_builder
    pr_content_builder -->|"creates or finds PR/MR"| pr_executor
  end

  structured_output -->|"writes title/body/mermaid"| description_json
  description_json -->|"supplies title/body/diagram"| create_pr_step

  classDef unchanged stroke:#626D84,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef added stroke:#29A34A,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef updated stroke:#6B5FCE,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef removed stroke:#D92424,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef subgraphStyle fill:transparent,stroke:#C0C5CF,stroke-width:1px,stroke-dasharray:5 5,rx:8,ry:8
  class describe_stage,artifacts_stage,create_pr_stage subgraphStyle
```

## Key changes made
- Updated the describe-step agent contract to require `mermaid_diagram` in addition to `title` and `markdown_body`.
- Added writing of `description.json` in the artifacts directory with `title`, `body`, `mermaid_diagram`, and `generated_at`.
- Kept the human-readable description artifact output and now appends a Mermaid code block consistently.
- Updated create-PR prompt instructions to:
  - Use `description.json` fields for PR title/body when present.
  - Embed `mermaid_diagram` as a fenced Mermaid block.
  - Include an explicit optional `Diagram` section in the PR structure.

## How was this tested
- `cargo test -p airlock-daemon stage_loader::tests:: -- --nocapture`
- `cargo test -p airlock-daemon -- --nocapture`
- Manual stage-script validation with stubbed `airlock`/`gh` binaries covering:
  - `defaults/describe/step.yml` no-diff path writes minimal `description.json`.
  - `defaults/describe/step.yml` diff path writes `description.json` with `title`, `body`, `mermaid_diagram`, and numeric `generated_at`.
  - `defaults/create-pr/step.yml` prompt includes the `description.json`/`mermaid_diagram` guidance and executes successfully with mocked PR creation.
