### PR TITLE
fix(defaults): replace jq with airlock exec json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,25 @@ E2E tests must reflect **end-user-visible behavior**. Do things the way a real u
 - **Test full round trips.** If init changes something, test that eject reverses it correctly by running init then eject, not by manually constructing post-init state.
 - **Before writing any test, verify which code path the CLI actually uses.** The daemon handler and CLI command may have separate implementations. A test that only covers one is incomplete.
 
+## Pipeline Step Scripts (defaults/)
+
+Step scripts in `defaults/*/step.yml` run on user machines. **Never use `jq`** — it's not universally installed. Use `airlock exec json` instead:
+
+```bash
+# Extract a field
+TITLE=$(echo "$RESPONSE" | airlock exec json title)
+
+# Extract nested field
+VALUE=$(echo "$RESPONSE" | airlock exec json a.b.c)
+
+# Build JSON from scratch (--set values auto-detect types: numbers, booleans, strings)
+echo '{}' | airlock exec json \
+    --set "title=$TITLE" \
+    --set "count=42" \
+    --set "passed=true" \
+    > output.json
+```
+
 ## Code Organization
 
 ### File Size Guidelines

--- a/defaults/critique/step.yml
+++ b/defaults/critique/step.yml
@@ -52,14 +52,13 @@ run: |
 
   # Parse response
   SUMMARY=$(echo "$RESPONSE" | airlock exec json summary)
-  COMMENTS=$(echo "$RESPONSE" | jq -c '.comments')
-  COMMENT_COUNT=$(echo "$COMMENTS" | jq 'length')
+  COMMENTS=$(echo "$RESPONSE" | airlock exec json comments)
 
-  echo "Critique complete: $COMMENT_COUNT comment(s)"
+  echo "Critique complete"
   echo "Summary: $SUMMARY"
 
   # Write comments as artifact (if any)
-  if [[ "$COMMENT_COUNT" -gt 0 ]]; then
+  if [[ "$COMMENTS" != "[]" ]]; then
       # Write batch file and submit as comment artifact
       BATCH_FILE=$(mktemp)
       echo "$COMMENTS" > "$BATCH_FILE"

--- a/defaults/describe/step.yml
+++ b/defaults/describe/step.yml
@@ -87,11 +87,11 @@ run: |
 
   # Write description.json for downstream stages (e.g. create-pr)
   mkdir -p "$AIRLOCK_ARTIFACTS"
-  jq -n \
-    --arg title "$TITLE" \
-    --arg body "$BODY" \
-    --arg diagram "$DIAGRAM" \
-    '{"title": $title, "body": $body, "mermaid_diagram": $diagram, "generated_at": now}' \
+  echo '{}' | airlock exec json \
+    --set "title=$TITLE" \
+    --set "body=$BODY" \
+    --set "mermaid_diagram=$DIAGRAM" \
+    --set "generated_at=$(date +%s)" \
     > "$AIRLOCK_ARTIFACTS/description.json"
 
   # Write as content artifact for display in UI (text summary + mermaid diagram)

--- a/defaults/document/step.yml
+++ b/defaults/document/step.yml
@@ -97,15 +97,13 @@ run: |
   esac
 
   # Write document_result.json for compatibility
-  cat > "$AIRLOCK_ARTIFACTS/document_result.json" << EOF
-  {
-    "verdict": $(echo "$VERDICT" | jq -Rs .),
-    "summary": $(echo "$SUMMARY" | jq -Rs .),
-    "details": $(echo "$DETAILS" | jq -Rs .),
-    "updates_applied": $UPDATES_APPLIED,
-    "exit_code": $EXIT_CODE,
-    "documented_at": $(date +%s)
-  }
-  EOF
+  echo '{}' | airlock exec json \
+    --set "verdict=$VERDICT" \
+    --set "summary=$SUMMARY" \
+    --set "details=$DETAILS" \
+    --set "updates_applied=$UPDATES_APPLIED" \
+    --set "exit_code=$EXIT_CODE" \
+    --set "documented_at=$(date +%s)" \
+    > "$AIRLOCK_ARTIFACTS/document_result.json"
 
   exit $EXIT_CODE

--- a/defaults/lint/step.yml
+++ b/defaults/lint/step.yml
@@ -155,16 +155,14 @@ run: |
 
   # Write lint_result.json for compatibility
   mkdir -p "$AIRLOCK_ARTIFACTS"
-  cat > "$AIRLOCK_ARTIFACTS/lint_result.json" << EOF
-  {
-    "verdict": $(echo "$VERDICT" | jq -Rs .),
-    "summary": $(echo "$SUMMARY" | jq -Rs .),
-    "details": $(echo "$DETAILS" | jq -Rs .),
-    "fixes_applied": $FIXES_APPLIED,
-    "passed": $PASSED,
-    "exit_code": $EXIT_CODE,
-    "linted_at": $(date +%s)
-  }
-  EOF
+  echo '{}' | airlock exec json \
+    --set "verdict=$VERDICT" \
+    --set "summary=$SUMMARY" \
+    --set "details=$DETAILS" \
+    --set "fixes_applied=$FIXES_APPLIED" \
+    --set "passed=$PASSED" \
+    --set "exit_code=$EXIT_CODE" \
+    --set "linted_at=$(date +%s)" \
+    > "$AIRLOCK_ARTIFACTS/lint_result.json"
 
   exit $EXIT_CODE

--- a/defaults/test/step.yml
+++ b/defaults/test/step.yml
@@ -108,15 +108,13 @@ run: |
   fi
 
   # Write test_result.json for compatibility
-  cat > "$AIRLOCK_ARTIFACTS/test_result.json" << EOF
-  {
-    "verdict": $(echo "$VERDICT" | jq -Rs .),
-    "summary": $(echo "$SUMMARY" | jq -Rs .),
-    "details": $(echo "$DETAILS" | jq -Rs .),
-    "passed": $PASSED,
-    "exit_code": $EXIT_CODE,
-    "tested_at": $(date +%s)
-  }
-  EOF
+  echo '{}' | airlock exec json \
+    --set "verdict=$VERDICT" \
+    --set "summary=$SUMMARY" \
+    --set "details=$DETAILS" \
+    --set "passed=$PASSED" \
+    --set "exit_code=$EXIT_CODE" \
+    --set "tested_at=$(date +%s)" \
+    > "$AIRLOCK_ARTIFACTS/test_result.json"
 
   exit $EXIT_CODE


### PR DESCRIPTION
## Summary
Replaced `jq` usage in default pipeline step scripts with `airlock exec json` so steps run reliably on user machines without extra dependencies. JSON artifact contracts remain intact while parsing/writing is standardized.

## Diagram
```mermaid
flowchart TD
  subgraph docs["Repository Guidance"]
    direction TB
    agents["AGENTS.md Pipeline Script Rules (updated)"]:::updated
  end

  subgraph steps["Default Pipeline Steps"]
    direction TB
    critique["Critique Step Script (updated)"]:::updated
    describe["Describe Step Script (updated)"]:::updated
    document["Document Step Script (updated)"]:::updated
    lint["Lint Step Script (updated)"]:::updated
    test["Test Step Script (updated)"]:::updated
  end

  subgraph tools["JSON Processing Tooling"]
    direction TB
    airlockJson["airlock exec json (unchanged)"]:::unchanged
    jqDep["jq dependency in step scripts (removed)"]:::removed
  end

  subgraph outputs["Pipeline Artifacts"]
    direction TB
    descJson["description.json output (unchanged)"]:::unchanged
    resultJson["*_result.json outputs (unchanged)"]:::unchanged
    critiqueArtifact["Critique comment artifact flow (updated)"]:::updated
  end

  agents -->|"documents required approach for"| critique
  agents -->|"documents required approach for"| describe
  agents -->|"documents required approach for"| document
  agents -->|"documents required approach for"| lint
  agents -->|"documents required approach for"| test

  critique -->|"parses response fields with"| airlockJson
  describe -->|"constructs JSON via"| airlockJson
  document -->|"constructs JSON via"| airlockJson
  lint -->|"constructs JSON via"| airlockJson
  test -->|"constructs JSON via"| airlockJson

  critique -->|"no longer depends on"| jqDep
  describe -->|"no longer depends on"| jqDep
  document -->|"no longer depends on"| jqDep
  lint -->|"no longer depends on"| jqDep
  test -->|"no longer depends on"| jqDep

  describe -->|"writes"| descJson
  document -->|"writes"| resultJson
  lint -->|"writes"| resultJson
  test -->|"writes"| resultJson
  critique -->|"conditionally emits"| critiqueArtifact

  classDef unchanged stroke:#626D84,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef added stroke:#29A34A,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef updated stroke:#6B5FCE,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef removed stroke:#D92424,stroke-width:2px,fill:transparent,color:#1B2236,rx:8,ry:8
  classDef subgraphStyle fill:transparent,stroke:#C0C5CF,stroke-width:1px,stroke-dasharray:5 5,rx:8,ry:8
  class docs,steps,tools,outputs subgraphStyle
```

## Key changes made
- Added a `Pipeline Step Scripts (defaults/)` section in `AGENTS.md` that explicitly forbids `jq` and documents `airlock exec json` usage patterns.
- Updated `defaults/describe/step.yml`, `defaults/document/step.yml`, `defaults/lint/step.yml`, and `defaults/test/step.yml` to build artifact JSON via `echo '{}' | airlock exec json --set ...`.
- Updated `defaults/critique/step.yml` to parse `comments` with `airlock exec json`, remove `jq`-based length counting, and emit comment artifacts only when comments are not `[]`.

## How was this tested
- `cargo test -p airlock-daemon stage_loader::tests::`
- `cargo test -p airlock-cli test_json_args_`
- `cargo test -p airlock-cli test_workflow_config_parsing_main_pipeline`
- `target/debug/airlock exec json`
- `defaults/{critique,describe,document,lint,test}/step.yml`
- `[]`
- `--set`
- `=`
- Lint/format checks passed for changed files.
