### PR TITLE
fix(gate): remove summary heading from risk

### DIFF
--- a/defaults/gate/step.yml
+++ b/defaults/gate/step.yml
@@ -120,7 +120,6 @@ run: |
   - **Approval Threshold:** $RISK_APPROVAL_THRESHOLD
   - **Decision:** $DECISION
 
-  ## Summary
   $SUMMARY
 
   ## Rationale


### PR DESCRIPTION
## Summary

Removes the redundant `## Summary` heading from the risk assessment artifact in the gate step. The summary text (`$SUMMARY`) is now rendered as a plain paragraph directly after the metadata fields, reducing visual noise in the assessment output.

## Diagram

```mermaid
flowchart TD
    step_yml["gate/step.yml (updated)"]
    risk_content["Risk Assessment Content (updated)"]
    artifact_cmd["airlock artifact content (unchanged)"]

    step_yml -- "generates" --> risk_content
    risk_content -- "piped to" --> artifact_cmd
```

## Key changes

- **`defaults/gate/step.yml`**: Removed the `## Summary` markdown heading that preceded the `$SUMMARY` variable in the risk assessment content template. The summary text now flows naturally as body text between the metadata block and the `## Rationale` section.

## How was this tested

- Verified the gate step produces risk assessment output without the redundant heading
- Confirmed the summary text renders correctly as a plain paragraph