### PR TITLE
feat: add risk assessment to PR description

### DIFF
--- a/defaults/create-pr/step.yml
+++ b/defaults/create-pr/step.yml
@@ -68,9 +68,14 @@ run: |
     - If a \`mermaid_diagram\` field is present, include it in the PR description as a fenced mermaid code block (\\\`\\\`\\\`mermaid ... \\\`\\\`\\\`). You MUST strip all Mermaid styling before including it: remove all \`classDef\` lines, \`class ... subgraphStyle\` lines, and \`:::className\` suffixes from nodes. GitHub/GitLab render Mermaid with their own dark/light theming, so custom styles break that.
   - If description.json does not exist, generate a title and description from the branch name and commit history
   - Do NOT add a signature for who created the PR/MR
+  - Check if \`\$AIRLOCK_ARTIFACTS/risk_assessment.json\` exists. If it does, include a **Risk Assessment** line in the PR description after the Summary section. Format it as:
+    - 🟢 for low risk, 🟡 for medium risk, 🔴 for high risk
+    - Follow the emoji with the \`risk_level\` value and the \`summary\` field as a one-liner
+    - Example: \"**Risk Assessment:** 🟢 Low — Minor copy change with no logic impact\"
   - The description should have these sections:
     - Summary (of the rationale behind the change)
-    - Diagram (only if a mermaid diagram is available from description.json)
+    - Risk Assessment (only if risk_assessment.json exists — one line with emoji + level + summary)
+    - Architecture (only if a mermaid diagram is available from description.json)
     - Key changes made
     - How was this tested
 


### PR DESCRIPTION
## Summary

The create-pr pipeline step now incorporates risk assessment data into generated PR descriptions. When a `risk_assessment.json` artifact exists from a prior pipeline stage, the agent includes a color-coded risk line (🟢/🟡/🔴) in the PR body, giving reviewers immediate visibility into the change's risk level.

**Risk Assessment:** 🟢 Low — Adds risk assessment display to PR description template via prompt instructions — no logic changes, just prompt text.

## Architecture

```mermaid
flowchart TD
    pipeline["Pipeline Execution (unchanged)"]
    risk_artifact["risk_assessment.json artifact (unchanged)"]
    desc_artifact["description.json artifact (unchanged)"]
    step_yml["create-pr/step.yml (updated)"]
    agent_prompt["Agent Prompt (updated)"]
    pr_output["PR Description (updated)"]

    pipeline -- "produces" --> risk_artifact
    pipeline -- "produces" --> desc_artifact
    step_yml -- "builds" --> agent_prompt
    agent_prompt -- "reads" --> risk_artifact
    agent_prompt -- "reads" --> desc_artifact
    agent_prompt -- "generates" --> pr_output
```

## Key changes made

- **Risk assessment integration** — The agent prompt in `defaults/create-pr/step.yml` now instructs the AI to check for `$AIRLOCK_ARTIFACTS/risk_assessment.json` and render a one-liner with emoji, risk level, and summary after the Summary section.
- **PR description structure updated** — The "Diagram" section was renamed to "Architecture" and a new "Risk Assessment" section slot was added between Summary and Architecture in the prescribed section order.

## How was this tested

- Pipeline tests pass with existing test suite
- Critique returned info-level only (1 comment, max severity: info)