### PR TITLE
fix(nav): auto-navigate on superseded run

### DIFF
--- a/crates/airlock-app/src/hooks/use-auto-navigate.ts
+++ b/crates/airlock-app/src/hooks/use-auto-navigate.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useNavigate, useMatch } from 'react-router-dom';
 import { useAirlockEvent, AIRLOCK_EVENTS } from './use-airlock-events';
 import type { RunCreatedEvent } from './use-airlock-events';
@@ -13,9 +14,25 @@ export function useAutoNavigateToNewRun() {
 
   const { detail } = useRunDetail(currentRunId);
 
+  // Track whether the current run was superseded, so we can navigate
+  // immediately on the next RUN_CREATED without waiting for a refetch.
+  const supersededRef = useRef(false);
+
+  // Reset when the viewed run changes (manual navigation, etc.)
+  useEffect(() => {
+    supersededRef.current = false;
+  }, [currentRunId]);
+
+  useAirlockEvent<{ run_id: string }>(AIRLOCK_EVENTS.RUN_SUPERSEDED, (event) => {
+    if (currentRunId && event.run_id === currentRunId) {
+      supersededRef.current = true;
+    }
+  });
+
   useAirlockEvent<RunCreatedEvent>(AIRLOCK_EVENTS.RUN_CREATED, (event) => {
-    // Don't navigate away from an active run (or one still loading)
-    if (currentRunId && (!detail || ACTIVE_STATUSES.has(detail.run.status))) {
+    // Don't navigate away from an active run (or one still loading),
+    // unless it was just superseded by the incoming push.
+    if (currentRunId && !supersededRef.current && (!detail || ACTIVE_STATUSES.has(detail.run.status))) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes auto-navigation so the app immediately navigates to the new run when a push supersedes the currently viewed run. Previously, if a user was viewing an active run and a new push arrived that superseded it, the app would refuse to navigate away because the current run still appeared active (the status hadn't been refetched yet). Now, the `RUN_SUPERSEDED` event is tracked via a ref, allowing the `RUN_CREATED` handler to bypass the active-run guard.

**Risk Assessment:** 🟢 Low — Small, well-scoped hook change that uses a ref to track superseded state for immediate navigation on new runs.

## Architecture

```mermaid
flowchart TD
    run_superseded_event["RUN_SUPERSEDED event (unchanged)"]
    run_created_event["RUN_CREATED event (unchanged)"]
    superseded_ref["supersededRef (added)"]
    auto_navigate["useAutoNavigateToNewRun (updated)"]
    use_run_detail["useRunDetail (unchanged)"]
    navigate_fn["navigate() (unchanged)"]

    run_superseded_event -- "sets flag on ref" --> superseded_ref
    run_created_event -- "triggers handler" --> auto_navigate
    use_run_detail -- "provides run status" --> auto_navigate
    superseded_ref -- "bypasses active-run guard" --> auto_navigate
    auto_navigate -- "calls navigate to new run" --> navigate_fn
```

## Key changes

- **Added `supersededRef`**: A React ref that tracks whether the currently viewed run has been superseded, providing synchronous state that doesn't depend on async data refetching.
- **Listens to `RUN_SUPERSEDED` event**: When the current run is superseded, the ref is set to `true`, signaling that navigation should proceed on the next `RUN_CREATED`.
- **Reset on navigation**: The ref resets to `false` whenever `currentRunId` changes, preventing stale state after manual navigation.
- **Updated navigation guard**: The `RUN_CREATED` handler now checks `supersededRef.current` — if the run was superseded, it skips the active-status guard and navigates immediately.

## How was this tested

Automated tests pass. The fix was verified by simulating a push that supersedes a currently viewed run and confirming the app navigates to the new run immediately.