### PR TITLE
chore: deduplicate helper, tidy comments

### DIFF
--- a/crates/airlock-app/src-tauri/src/event_bridge.rs
+++ b/crates/airlock-app/src-tauri/src/event_bridge.rs
@@ -26,7 +26,7 @@ use interprocess::local_socket::{tokio::Stream, GenericNamespaced};
 /// JSON-RPC notification from the daemon.
 #[derive(Debug, Deserialize)]
 struct Notification {
-    /// Required by JSON-RPC 2.0 schema; consumed during deserialization.
+    /// Required by JSON-RPC 2.0; deserialized for schema compliance.
     #[allow(dead_code)]
     jsonrpc: String,
     method: String,
@@ -45,7 +45,7 @@ struct SubscribeRequest {
 /// JSON-RPC response.
 #[derive(Debug, Deserialize)]
 struct Response {
-    /// Present in successful responses; currently unused but part of the JSON-RPC schema.
+    /// Deserialized for schema compliance; only `error` is inspected.
     #[allow(dead_code)]
     result: Option<serde_json::Value>,
     error: Option<RpcError>,
@@ -53,7 +53,7 @@ struct Response {
 
 #[derive(Debug, Deserialize)]
 struct RpcError {
-    /// JSON-RPC error code; deserialized for completeness but only `message` is displayed.
+    /// Deserialized for schema compliance; only `message` is displayed.
     #[allow(dead_code)]
     code: i32,
     message: String,
@@ -118,9 +118,6 @@ async fn connect_to_daemon(paths: &AirlockPaths) -> Result<Stream, String> {
 pub async fn run_event_bridge<R: tauri::Runtime>(app_handle: tauri::AppHandle<R>) {
     let paths = AirlockPaths::default();
     let state = Arc::new(EventBridgeState::new());
-
-    // Store state in app for potential cleanup
-    // Note: In a real implementation, you might want to store this in Tauri's state management
 
     info!("Event bridge starting...");
 
@@ -258,6 +255,8 @@ fn emit_event_to_frontend<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     event: &AirlockEvent,
 ) {
+    use tauri_plugin_notification::NotificationExt;
+
     // Emit a general event with the full payload
     if let Err(e) = app_handle.emit("airlock://event", event) {
         warn!("Failed to emit event to frontend: {}", e);
@@ -266,7 +265,6 @@ fn emit_event_to_frontend<R: tauri::Runtime>(
     // Send OS notifications
     match event {
         AirlockEvent::RunCreated { branch, .. } => {
-            use tauri_plugin_notification::NotificationExt;
             if let Err(e) = app_handle
                 .notification()
                 .builder()
@@ -283,7 +281,6 @@ fn emit_event_to_frontend<R: tauri::Runtime>(
             branch,
             ..
         } if status == "awaiting_approval" => {
-            use tauri_plugin_notification::NotificationExt;
             let display_branch = branch.strip_prefix("refs/heads/").unwrap_or(branch);
             if let Err(e) = app_handle
                 .notification()
@@ -301,7 +298,6 @@ fn emit_event_to_frontend<R: tauri::Runtime>(
         AirlockEvent::RunCompleted {
             success, branch, ..
         } => {
-            use tauri_plugin_notification::NotificationExt;
             let display_branch = branch.strip_prefix("refs/heads/").unwrap_or(branch);
             let (title, body) = if *success {
                 (

--- a/crates/airlock-core/src/gui.rs
+++ b/crates/airlock-core/src/gui.rs
@@ -101,6 +101,10 @@ pub fn spawn_detached(gui_path: &PathBuf) -> Result<()> {
 
         let mut cmd = Command::new(gui_path);
 
+        // SAFETY: `setsid()` is called in the child process after `fork()` and
+        // before `exec()`.  It only affects the child's session/process-group and
+        // cannot fail in a way that corrupts the parent.  The closure captures no
+        // shared state, so there are no data-race concerns.
         unsafe {
             cmd.pre_exec(|| {
                 libc::setsid();

--- a/crates/airlock-core/src/lib.rs
+++ b/crates/airlock-core/src/lib.rs
@@ -60,7 +60,7 @@ pub use config::{
     TriggerConfig,
     WorkflowConfig,
 };
-pub use db::{job_status_to_string, string_to_job_status, Database};
+pub use db::{job_status_to_string, step_status_to_string, string_to_job_status, Database};
 pub use error::{AirlockError, Result};
 pub use git::{
     compute_diff, find_effective_base_sha, hooks, show_file, DiffResult, RefUpdateType,

--- a/crates/airlock-daemon/src/handlers/runs.rs
+++ b/crates/airlock-daemon/src/handlers/runs.rs
@@ -10,7 +10,7 @@ use crate::ipc::{
     GetRunsParams, GetRunsResult, JobResultInfo, RefUpdateParam, ReprocessRunParams,
     ReprocessRunResult, Response, RunDetailInfo, RunInfo, StepResultInfo,
 };
-use airlock_core::StepStatus;
+use airlock_core::step_status_to_string;
 use std::sync::Arc;
 use tracing::{info, warn};
 
@@ -425,16 +425,4 @@ pub async fn handle_cancel_run(
     };
 
     Response::success(id, serde_json::to_value(result).unwrap())
-}
-
-/// Convert StepStatus to string for IPC responses.
-fn step_status_to_string(status: StepStatus) -> &'static str {
-    match status {
-        StepStatus::Pending => "pending",
-        StepStatus::Running => "running",
-        StepStatus::Passed => "passed",
-        StepStatus::Failed => "failed",
-        StepStatus::Skipped => "skipped",
-        StepStatus::AwaitingApproval => "awaiting_approval",
-    }
 }

--- a/crates/airlock-fixtures/src/db_export.rs
+++ b/crates/airlock-fixtures/src/db_export.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use std::path::Path;
 
 // Import database and types from airlock-core
-use airlock_core::{AirlockPaths, Database, Run, StepStatus};
+use airlock_core::{step_status_to_string, AirlockPaths, Database, Run};
 
 // Import IPC types from airlock-daemon for exact serialization matching
 use airlock_daemon::ipc::{
@@ -483,18 +483,6 @@ fn write_index(output_dir: &Path, repos: &[ExportedRepo]) -> Result<()> {
     println!("  index.json -> {}", path.display());
 
     Ok(())
-}
-
-/// Convert StepStatus to string for IPC responses.
-fn step_status_to_string(status: StepStatus) -> &'static str {
-    match status {
-        StepStatus::Pending => "pending",
-        StepStatus::Running => "running",
-        StepStatus::Passed => "passed",
-        StepStatus::Failed => "failed",
-        StepStatus::Skipped => "skipped",
-        StepStatus::AwaitingApproval => "awaiting_approval",
-    }
 }
 
 /// Load artifacts from a run's artifact directory.


### PR DESCRIPTION
## Summary

Cosmetic cleanup that removes duplicated `step_status_to_string` implementations, improves doc comments in the event bridge, and adds a required `SAFETY` comment to an `unsafe` block.

**Risk Assessment:** 🟢 Low — Pure cosmetic cleanup: deduplicates a helper function, adds a SAFETY comment, and tidies imports — no behavioral changes.

## Architecture

```mermaid
flowchart TD
    core_lib["airlock-core::lib re-export (updated)"]
    step_status["step_status_to_string (unchanged)"]
    daemon_runs["handlers::runs (updated)"]
    db_export["db_export (updated)"]
    event_bridge["event_bridge (updated)"]
    gui["gui::spawn_detached (updated)"]

    core_lib -- "now re-exports" --> step_status
    daemon_runs -- "imports from core" --> core_lib
    db_export -- "imports from core" --> core_lib
```

## Key changes

- **Deduplicated `step_status_to_string`**: Removed duplicate implementations from `airlock-daemon` and `airlock-fixtures`, re-exporting the canonical version from `airlock-core` via `lib.rs`
- **Tidied `event_bridge.rs`**: Hoisted the `use tauri_plugin_notification::NotificationExt` import to function scope (eliminating 3 duplicate inner imports), shortened `#[allow(dead_code)]` doc comments, and removed a stale TODO-style comment
- **Added `SAFETY` comment**: Documented the `unsafe pre_exec` block in `gui.rs::spawn_detached` explaining why the `setsid()` call is sound

## How was this tested

Existing test suite passes. No behavioral changes introduced.