### PR TITLE
ci: fix cargo cache key glob pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -68,7 +68,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 
@@ -102,7 +102,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-
 


### PR DESCRIPTION
## Summary

Fixes CI cargo cache misses by narrowing the `Cargo.lock` hash glob from `**/Cargo.lock` to `Cargo.lock`. The recursive glob could match lock files in nested directories (e.g., inside `target/`), producing unstable cache keys and causing unnecessary cache invalidation or build failures.

**Risk Assessment:** 🟢 Low — CI-only cache key fix with no application code changes, zero critique issues, and appropriately skipped tests.

## Architecture

```mermaid
flowchart TD
    ci_yml[".github/workflows/ci.yml (updated)"]

    subgraph ci_jobs["CI Jobs"]
        direction TB
        check_job["check job (updated)"]
        test_job["test job (updated)"]
        build_job["build job (updated)"]
    end

    ci_yml -- "defines" --> ci_jobs
    check_job -- "cache key: hashFiles Cargo.lock" --> cargo_lock["Cargo.lock (unchanged)"]
    test_job -- "cache key: hashFiles Cargo.lock" --> cargo_lock
    build_job -- "cache key: hashFiles Cargo.lock" --> cargo_lock
```

## Key changes

- **`.github/workflows/ci.yml`** — Updated the `hashFiles` glob in all three job cache keys (`check`, `test`, `build`) from `**/Cargo.lock` to `Cargo.lock`, targeting only the root lock file for deterministic cache key generation.

## How was this tested

Tests were appropriately skipped — this is a CI-only configuration change with no application code impact.