### PR TITLE
ci: add release-to-issue notifications

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -245,18 +245,12 @@ jobs:
 
           echo "Finding PRs between ${prev_tag} and ${TAG_NAME}"
 
-          # Get the date of the previous release to scope the commit list
-          prev_date=$(gh api repos/${{ github.repository }}/releases \
-            --jq "[.[] | select(.tag_name != \"${TAG_NAME}\")] | first | .published_at")
+          # Use compare API — excludes base tag's commits (unlike commits?since= which is inclusive)
+          # Note: capped at 250 commits, but sufficient for typical release cadences
+          commits=$(gh api repos/${{ github.repository }}/compare/${prev_tag}...${TAG_NAME} \
+            --jq '.commits[].sha')
 
-          # Use the commits list API with real pagination (compare API caps at 250)
-          commits=$(gh api repos/${{ github.repository }}/commits \
-            --paginate \
-            -f sha="${TAG_NAME}" \
-            -f since="${prev_date}" \
-            --jq '.[].sha')
-
-          # Collect unique PR numbers across all commits first (avoids duplicate timeline queries)
+          # Collect unique PR numbers across all commits (avoids duplicate queries per PR)
           declare -A seen_prs
           for sha in $commits; do
             prs=$(gh api repos/${{ github.repository }}/commits/${sha}/pulls \
@@ -266,21 +260,16 @@ jobs:
             done
           done
 
-          # For each unique PR, find linked issues and comment
+          # For each unique PR, find linked issues via body regex and comment
           declare -A seen_issues
           for pr in "${!seen_prs[@]}"; do
-            # Get issues linked via sidebar (connected events use .url, not .source)
-            connected_issues=$(gh api repos/${{ github.repository }}/issues/${pr}/timeline \
-              --paginate --jq '.[] | select(.event == "connected") | .url' 2>/dev/null \
-              | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' || true)
-
             # Check the PR body for "Fixes #N" / "Closes #N" patterns (same-repo only, excludes org/repo#N)
-            body_issues=$(gh api repos/${{ github.repository }}/pulls/${pr} \
+            issues=$(gh api repos/${{ github.repository }}/pulls/${pr} \
               --jq '.body' 2>/dev/null \
               | grep -oiE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+' \
               | grep -oE '[0-9]+' || true)
 
-            for issue in $connected_issues $body_issues; do
+            for issue in $issues; do
               if [ -z "${seen_issues[$issue]+x}" ]; then
                 seen_issues[$issue]=1
                 echo "Commenting on issue #${issue}"


### PR DESCRIPTION
## Summary

Adds a `notify-issues` job to the release-please workflow that automatically comments on GitHub issues when they are included in a new release. When a release is created, it finds all PRs between the previous and current tag, extracts linked issue numbers from PR bodies (via `Fixes #N` / `Closes #N` patterns), and posts a comment with a link to the release.

**Risk Assessment:** 🟢 Low — CI-only change adding a non-critical release notification job with no impact on application code.

## Architecture

```mermaid
flowchart TD
    push_event["push to main (unchanged)"]
    release_please["release-please job (unchanged)"]
    notify_issues["notify-issues job (added)"]
    permissions["Workflow permissions (updated)"]

    push_event -- "triggers" --> release_please
    release_please -- "airlock-release-created == true" --> notify_issues
    permissions -- "issues: write added" --> notify_issues

    subgraph notify_steps["notify-issues steps"]
        direction TB
        prev_tag["Get previous tag (added)"]
        compare["Compare commits between tags (added)"]
        map_prs["Map commits to PRs (added)"]
        extract_issues["Extract linked issues from PR bodies (added)"]
        comment["Comment on issues with release link (added)"]

        prev_tag -- "prev_tag" --> compare
        compare -- "commit SHAs" --> map_prs
        map_prs -- "unique PR numbers" --> extract_issues
        extract_issues -- "unique issue numbers" --> comment
    end

    notify_issues --> prev_tag

    subgraph gh_apis["GitHub APIs"]
        direction TB
        releases_api["Releases API (unchanged)"]
        compare_api["Compare API (unchanged)"]
        commits_pulls_api["Commits/Pulls API (unchanged)"]
        issues_api["Issues API (unchanged)"]
    end

    prev_tag -- "fetches releases" --> releases_api
    compare -- "fetches commit diff" --> compare_api
    map_prs -- "fetches PRs per commit" --> commits_pulls_api
    comment -- "posts comment" --> issues_api
```

## Key changes

- **`issues: write` permission** — Added to the workflow-level permissions block to allow commenting on issues.
- **`notify-issues` job** — New job that runs after `release-please` when a release is created:
  - Fetches the previous release tag via the GitHub Releases API.
  - Uses the compare API to get commits between the two tags (capped at 250 commits).
  - Maps commits → PRs → linked issues, deduplicating at each step.
  - Posts a comment on each resolved issue with a link to the release.

## How was this tested

CI-only change — verified workflow syntax is valid. No application code was modified.