### PR TITLE
chore: remove restating comments and slop

### DIFF
--- a/crates/airlock-app/src-tauri/src/event_bridge.rs
+++ b/crates/airlock-app/src-tauri/src/event_bridge.rs
@@ -26,7 +26,6 @@ use interprocess::local_socket::{tokio::Stream, GenericNamespaced};
 /// JSON-RPC notification from the daemon.
 #[derive(Debug, Deserialize)]
 struct Notification {
-    /// Required by JSON-RPC 2.0; deserialized for schema compliance but not inspected.
     #[serde(rename = "jsonrpc")]
     _jsonrpc: String,
     method: String,
@@ -45,7 +44,6 @@ struct SubscribeRequest {
 /// JSON-RPC response.
 #[derive(Debug, Deserialize)]
 struct Response {
-    /// Deserialized for schema compliance; only `error` is inspected.
     #[serde(rename = "result")]
     _result: Option<serde_json::Value>,
     error: Option<RpcError>,
@@ -53,7 +51,6 @@ struct Response {
 
 #[derive(Debug, Deserialize)]
 struct RpcError {
-    /// Deserialized for schema compliance; only `message` is displayed.
     #[serde(rename = "code")]
     _code: i32,
     message: String,

--- a/crates/airlock-core/src/agent/mod.rs
+++ b/crates/airlock-core/src/agent/mod.rs
@@ -30,10 +30,7 @@ pub use types::{
 ///
 /// Each adapter wraps a specific agent CLI (e.g., Claude Code, Codex) and
 /// translates its native output into a unified stream of [`AgentEvent`] values.
-///
-/// Streaming is the only execution mode — there is no separate non-streaming
-/// `run()` method. Callers that need a collected result drain the stream with
-/// [`StreamCollector`].
+/// Callers that need a collected result drain the stream with [`StreamCollector`].
 #[async_trait]
 pub trait AgentAdapter: Send + Sync {
     /// Human-readable name (e.g., "Claude Code", "Codex").
@@ -43,11 +40,6 @@ pub trait AgentAdapter: Send + Sync {
     fn is_available(&self) -> bool;
 
     /// Run a prompt and return a stream of events for real-time output.
-    ///
-    /// Streaming is the only execution mode — there is no non-streaming `run()`.
-    /// Each adapter does best effort to produce a consistent stream of
-    /// [`AgentEvent`] variants regardless of how the underlying CLI delivers
-    /// output.
     async fn run(&self, request: &AgentRequest) -> Result<AgentEventStream>;
 }
 

--- a/crates/airlock-core/src/agent/types.rs
+++ b/crates/airlock-core/src/agent/types.rs
@@ -1,7 +1,4 @@
 //! Unified types for the agent adapter system.
-//!
-//! These types provide a provider-agnostic interface for agent interactions.
-//! All adapters (Claude Code, Codex, etc.) map their native types to these.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/crates/airlock-core/src/lib.rs
+++ b/crates/airlock-core/src/lib.rs
@@ -34,42 +34,42 @@ pub mod service;
 pub mod types;
 pub mod worktree;
 
+// --- Agent types ---
 pub use agent::{
     create_adapter, try_extract_json, AgentAdapter, AgentEvent, AgentEventStream, AgentMessage,
     AgentRequest, AgentResult, AgentUsage, ClaudeCodeAdapter, CodexAdapter, ContentBlock,
     StreamCollector,
 };
+
+// --- Config types ---
 pub use config::{
-    // Workflow config
-    branch_matches_trigger,
-    filter_workflows_for_branch,
-    // Config loading utilities
-    load_global_config,
-    load_workflows_from_disk,
-    load_workflows_from_tree,
-    parse_workflow_config,
-    validate_job_dag,
-    // Common config types
-    AgentGlobalConfig,
-    AgentOptions,
-    DagValidationError,
-    GlobalConfig,
-    JobConfig,
-    OneOrMany,
-    PushTrigger,
-    TriggerConfig,
-    WorkflowConfig,
+    branch_matches_trigger, filter_workflows_for_branch, load_global_config,
+    load_workflows_from_disk, load_workflows_from_tree, parse_workflow_config, validate_job_dag,
+    AgentGlobalConfig, AgentOptions, DagValidationError, GlobalConfig, JobConfig, OneOrMany,
+    PushTrigger, TriggerConfig, WorkflowConfig,
 };
+
+// --- Database ---
 pub use db::{job_status_to_string, step_status_to_string, string_to_job_status, Database};
+
+// --- Error handling ---
 pub use error::{AirlockError, Result};
+
+// --- Git operations ---
 pub use git::{
     compute_diff, find_effective_base_sha, hooks, show_file, DiffResult, RefUpdateType,
     DEFAULT_BRANCHES, EMPTY_TREE_SHA,
 };
+
+// --- Initialization ---
 pub use init::{BYPASS_REMOTE, REPO_CONFIG_PATH};
+
+// --- Paths & providers ---
 pub use paths::AirlockPaths;
 pub use provider::{check_provider_setup, detect_provider, ProviderCheck, ScmProvider};
 pub use service::ServiceManager;
+
+// --- Domain types ---
 pub use types::{
     ApprovalMode, CleanResult, DependencyGraph, DiffAnalysis, DiffHunk, FileChange, FileStatus,
     FormatResult, GuidedTour, HunkDependencies, Intent, IntentCategory, IntentStatus, JobResult,
@@ -77,11 +77,9 @@ pub use types::{
     SecretFinding, SecretsResult, SplitAnalysis, SplitHunk, SplitIntent, StepDefinition,
     StepResult, StepStatus, SyncLog, TourResult, TourStep,
 };
+
+// --- Worktree management ---
 pub use worktree::{
     create_run_worktree, is_valid_worktree, list_worktrees, remove_run_worktree, remove_worktree,
     reset_persistent_worktree,
 };
-
-// Legacy intent-centric functions (create_intent_worktree, create_intent_branch,
-// hunks_to_patch, apply_patch) removed from public API. See worktree.rs for
-// deprecation notes (steps 10.13-10.16).

--- a/crates/airlock-core/src/worktree.rs
+++ b/crates/airlock-core/src/worktree.rs
@@ -1,25 +1,13 @@
 //! Git worktree management for pipeline execution.
 //!
-//! This module provides utilities for creating and managing git worktrees
-//! used during pipeline processing.
+//! Provides utilities for creating and managing git worktrees used during
+//! stage-based pipeline processing.
 //!
-//! ## Stage-Based Pipeline (Recommended)
-//!
-//! The stage-based pipeline uses a single worktree per run:
 //! - [`create_run_worktree`] - Create worktree at head commit
 //! - [`remove_run_worktree`] - Remove a run's worktree
 //! - [`list_worktrees`] - List all worktrees for a repo
 //!
 //! Worktree path format: `~/.airlock/worktrees/<repo_id>/<run_id>`
-//!
-//! ## Legacy Intent-Centric Pipeline (DEPRECATED)
-//!
-//! The following functions are for the legacy intent-centric pipeline and
-//! will be removed in steps 10.13-10.16:
-//! - [`create_intent_worktree`] - Create worktree with patch application
-//! - [`create_intent_branch`] - Create branch and commit in worktree
-//! - [`hunks_to_patch`] - Convert hunks to unified diff patch
-//! - [`apply_patch`] - Apply patch to worktree
 
 use crate::error::{AirlockError, Result};
 use crate::types::SplitHunk;


### PR DESCRIPTION
## Summary

Cleans up AI-generated slop across the codebase: removes comments that restate what the code already says, trims verbose doc comments that repeat themselves, deletes stale "legacy/deprecated" references to functions that no longer exist, and reorganizes `lib.rs` re-exports into clearly labeled sections.

**Risk Assessment:** 🟢 Low — Pure comment/doc cleanup and re-export reformatting with no logic changes.

## Architecture

```mermaid
flowchart TD
    lib_rs["lib.rs re-exports (updated)"]
    event_bridge["event_bridge.rs (updated)"]
    agent_mod["AgentAdapter trait (updated)"]
    agent_types["agent/types.rs (updated)"]
    worktree["worktree.rs (updated)"]

    lib_rs -- "re-exports from" --> agent_mod
    lib_rs -- "re-exports from" --> worktree
    lib_rs -- "re-exports from" --> agent_types
    event_bridge -- "deserializes" --> rpc_structs["Notification / Response / RpcError (updated)"]
```

## Key changes made

- **`event_bridge.rs`** — Removed 3 doc comments on struct fields that just restated the `#[serde(rename)]` attribute or the field's obvious purpose.
- **`agent/mod.rs`** — Trimmed `AgentAdapter` trait docs: removed a paragraph that repeated "streaming is the only execution mode" twice.
- **`agent/types.rs`** — Removed module-level doc comment that restated the module name.
- **`lib.rs`** — Reorganized all `pub use` re-exports into labeled sections (`Agent types`, `Config types`, `Database`, etc.) and removed a stale comment block referencing legacy functions that were already deleted.
- **`worktree.rs`** — Condensed module-level docs: removed "Legacy Intent-Centric Pipeline (DEPRECATED)" section referencing functions that no longer exist, and tightened the remaining description.

## How was this tested

No runtime behavior, types, or logic changed — this is pure comment/doc cleanup and re-export reformatting. Existing tests pass.