### PR TITLE
feat(daemon): add retry_job IPC method

### DIFF
--- a/crates/airlock-app/src-tauri/src/ipc/runs.rs
+++ b/crates/airlock-app/src-tauri/src/ipc/runs.rs
@@ -2,7 +2,8 @@
 
 use super::error::IpcError;
 use super::types::{
-    DaemonCancelRunResult, DaemonGetRunsResult, DaemonReprocessRunResult, DaemonRunDetailResult,
+    DaemonCancelRunResult, DaemonGetRunsResult, DaemonReprocessRunResult, DaemonRetryJobResult,
+    DaemonRunDetailResult,
 };
 use super::IpcClient;
 use crate::{ApplyPatchesResult, ApproveStepResult, GetRunDiffResult, RunDetail, RunInfo};
@@ -59,6 +60,19 @@ impl IpcClient {
             .await?;
 
         let daemon_result: DaemonReprocessRunResult = serde_json::from_value(result)?;
+        Ok(daemon_result.success)
+    }
+
+    /// Retry a specific failed/skipped job within a run
+    pub async fn retry_job(&self, run_id: &str, job_key: &str) -> Result<bool, IpcError> {
+        let result = self
+            .send_request(
+                "retry_job",
+                serde_json::json!({ "run_id": run_id, "job_key": job_key }),
+            )
+            .await?;
+
+        let daemon_result: DaemonRetryJobResult = serde_json::from_value(result)?;
         Ok(daemon_result.success)
     }
 

--- a/crates/airlock-app/src-tauri/src/ipc/types.rs
+++ b/crates/airlock-app/src-tauri/src/ipc/types.rs
@@ -138,3 +138,8 @@ pub(crate) struct DaemonReprocessRunResult {
 pub(crate) struct DaemonCancelRunResult {
     pub success: bool,
 }
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DaemonRetryJobResult {
+    pub success: bool,
+}

--- a/crates/airlock-app/src-tauri/src/lib.rs
+++ b/crates/airlock-app/src-tauri/src/lib.rs
@@ -191,6 +191,20 @@ async fn reprocess_run(state: State<'_, AppState>, run_id: String) -> Result<boo
         .map_err(|e| e.to_string())
 }
 
+/// Retry a specific failed/skipped job within a run
+#[tauri::command]
+async fn retry_job(
+    state: State<'_, AppState>,
+    run_id: String,
+    job_key: String,
+) -> Result<bool, String> {
+    state
+        .ipc_client
+        .retry_job(&run_id, &job_key)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Cancel a running pipeline run
 #[tauri::command]
 async fn cancel_run(state: State<'_, AppState>, run_id: String) -> Result<bool, String> {
@@ -532,6 +546,7 @@ pub fn run() {
             get_intent_diff,
             get_intent_tour,
             reprocess_run,
+            retry_job,
             cancel_run,
             approve_intent,
             reject_intent,

--- a/crates/airlock-app/src/components/StagesSidebar.tsx
+++ b/crates/airlock-app/src/components/StagesSidebar.tsx
@@ -1,6 +1,6 @@
 import { Button, StatusDot } from '@airlock-hq/design-system/react';
 import type { StepResultInfo, JobResultInfo } from '@/hooks/use-daemon';
-import { CheckCircle2, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { CheckCircle2, ChevronDown, ChevronRight, Loader2, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getStatusConfig } from '@/lib/status-utils';
 import { useState } from 'react';
@@ -19,6 +19,8 @@ interface StagesSidebarProps {
   onSelectStep: (selection: StepSelection) => void;
   onApprove?: (jobKey: string, stepName: string) => Promise<void>;
   approvingStep?: StepSelection | null;
+  onRetryJob?: (jobKey: string) => Promise<void>;
+  retryingJob?: string | null;
 }
 
 /**
@@ -33,6 +35,8 @@ export function StagesSidebar({
   onSelectStep,
   onApprove,
   approvingStep,
+  onRetryJob,
+  retryingJob,
 }: StagesSidebarProps) {
   const isSingleJob = jobs.length <= 1;
   const [collapsedJobs, setCollapsedJobs] = useState<Set<string>>(new Set());
@@ -61,12 +65,28 @@ export function StagesSidebar({
   // Sort jobs by job_order
   const sortedJobs = [...jobs].sort((a, b) => a.job_order - b.job_order);
 
+  const singleJob = isSingleJob ? jobs[0] : undefined;
+
   return (
     <div className="flex h-full flex-col">
-      <div className="border-border-subtle border-b px-4 py-3">
+      <div className="border-border-subtle flex items-center justify-between border-b px-4 py-3">
         <span className="text-micro text-foreground-muted font-mono tracking-widest uppercase">
           {isSingleJob ? 'Steps' : 'Jobs'}
         </span>
+        {singleJob && onRetryJob && (singleJob.status === 'failed' || singleJob.status === 'skipped') && (
+          <button
+            className="text-foreground-muted hover:text-foreground shrink-0 cursor-pointer p-0.5"
+            title="Retry this job"
+            onClick={() => onRetryJob(singleJob.job_key)}
+            disabled={retryingJob === singleJob.job_key}
+          >
+            {retryingJob === singleJob.job_key ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" />
+            )}
+          </button>
+        )}
       </div>
       <div className="flex-1 overflow-y-auto">
         {isSingleJob
@@ -104,6 +124,23 @@ export function StagesSidebar({
                     <span className="text-small min-w-0 flex-1 truncate font-medium">
                       {job.name || formatStageName(job.job_key)}
                     </span>
+                    {onRetryJob && (job.status === 'failed' || job.status === 'skipped') && (
+                      <button
+                        className="text-foreground-muted hover:text-foreground shrink-0 cursor-pointer p-0.5"
+                        title="Retry this job"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onRetryJob(job.job_key);
+                        }}
+                        disabled={retryingJob === job.job_key}
+                      >
+                        {retryingJob === job.job_key ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <RefreshCw className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    )}
                   </div>
 
                   {/* Steps within this job */}

--- a/crates/airlock-app/src/components/push-request/ActivityTab.tsx
+++ b/crates/airlock-app/src/components/push-request/ActivityTab.tsx
@@ -14,13 +14,25 @@ interface ActivityTabProps {
   artifacts: ArtifactInfo[];
   onApproveStep?: (jobKey: string, stepName: string) => Promise<void>;
   approvingStep?: StepSelection | null;
+  onRetryJob?: (jobKey: string) => Promise<void>;
+  retryingJob?: string | null;
 }
 
 /**
  * ActivityTab displays the pipeline jobs/steps sidebar and log viewer.
  * URL params: ?job=<key>&step=<name>
  */
-export function ActivityTab({ repoId, runId, jobs, steps, artifacts, onApproveStep, approvingStep }: ActivityTabProps) {
+export function ActivityTab({
+  repoId,
+  runId,
+  jobs,
+  steps,
+  artifacts,
+  onApproveStep,
+  approvingStep,
+  onRetryJob,
+  retryingJob,
+}: ActivityTabProps) {
   // Store selected step in URL search params
   const [searchParams, setSearchParams] = useSearchParams();
   const jobParam = searchParams.get('job');
@@ -79,6 +91,8 @@ export function ActivityTab({ repoId, runId, jobs, steps, artifacts, onApproveSt
           onSelectStep={handleSelectStep}
           onApprove={onApproveStep}
           approvingStep={approvingStep}
+          onRetryJob={onRetryJob}
+          retryingJob={retryingJob}
         />
       </ResizablePanel>
 

--- a/crates/airlock-app/src/hooks/use-daemon.ts
+++ b/crates/airlock-app/src/hooks/use-daemon.ts
@@ -385,6 +385,10 @@ export async function reprocessRun(runId: string): Promise<boolean> {
   return invoke<boolean>('reprocess_run', { runId });
 }
 
+export async function retryJob(runId: string, jobKey: string): Promise<boolean> {
+  return invoke<boolean>('retry_job', { runId, jobKey });
+}
+
 export async function cancelRun(runId: string): Promise<boolean> {
   return invoke<boolean>('cancel_run', { runId });
 }

--- a/crates/airlock-app/src/lib/tauri.ts
+++ b/crates/airlock-app/src/lib/tauri.ts
@@ -112,6 +112,13 @@ async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
       return description as T;
     }
 
+    case 'retry_job': {
+      const runId = args?.runId as string;
+      const jobKey = args?.jobKey as string;
+      console.log(`[Mock] Retry job ${jobKey} in run ${runId}`);
+      return true as T;
+    }
+
     case 'reprocess_run': {
       const runId = args?.runId as string;
       console.log(`[Mock] Reprocess run ${runId}`);

--- a/crates/airlock-app/src/pages/RunDetail.tsx
+++ b/crates/airlock-app/src/pages/RunDetail.tsx
@@ -9,6 +9,7 @@ import {
   getRepoNameFromUrl,
   reprocessRun,
   cancelRun,
+  retryJob,
   approveStep,
   readArtifact,
   applyPatches,
@@ -83,6 +84,7 @@ export function RunDetail() {
   }, [repos, repoId]);
   const [reprocessing, setReprocessing] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [retryingJob, setRetryingJob] = useState<string | null>(null);
   const [approvingStep, setApprovingStep] = useState<StepSelection | null>(null);
   const [allComments, setAllComments] = useState<CodeComment[]>([]);
   const [selectedComments, setSelectedComments] = useState<Set<string>>(new Set());
@@ -118,6 +120,22 @@ export function RunDetail() {
       setCancelling(false);
     }
   };
+
+  const handleRetryJob = useCallback(
+    async (jobKey: string) => {
+      if (!runId) return;
+      try {
+        setRetryingJob(jobKey);
+        await retryJob(runId, jobKey);
+        await refresh();
+      } catch (e) {
+        console.error('Retry job failed:', e);
+      } finally {
+        setRetryingJob(null);
+      }
+    },
+    [runId, refresh]
+  );
 
   const handleApproveStep = useCallback(
     async (jobKey: string, stepName: string) => {
@@ -555,6 +573,8 @@ export function RunDetail() {
                 artifacts={detail.artifacts}
                 onApproveStep={handleApproveStep}
                 approvingStep={approvingStep}
+                onRetryJob={handleRetryJob}
+                retryingJob={retryingJob}
               />
             </TabsContent>
 

--- a/crates/airlock-core/src/db/job_result.rs
+++ b/crates/airlock-core/src/db/job_result.rs
@@ -258,6 +258,27 @@ impl Database {
         Ok(results)
     }
 
+    /// Reset a job to Pending status, clearing started_at, completed_at, error, and worktree_path.
+    pub fn reset_job_to_pending(&self, job_id: &str) -> Result<()> {
+        let rows_affected = self
+            .conn
+            .execute(
+                "UPDATE job_results SET status = 'pending', started_at = NULL, completed_at = NULL, error = NULL, worktree_path = NULL
+                 WHERE id = ?1",
+                [job_id],
+            )
+            .map_err(|e| {
+                AirlockError::Database(format!("Failed to reset job to pending: {e}"))
+            })?;
+
+        if rows_affected == 0 {
+            return Err(AirlockError::NotFound("JobResult".into(), job_id.into()));
+        }
+
+        tracing::debug!("Reset job result to pending: {}", job_id);
+        Ok(())
+    }
+
     /// Update the worktree_path for a job result.
     pub fn update_job_worktree_path(&self, id: &str, worktree_path: &str) -> Result<()> {
         let rows_affected = self

--- a/crates/airlock-core/src/db/stage_result.rs
+++ b/crates/airlock-core/src/db/stage_result.rs
@@ -197,6 +197,25 @@ impl Database {
         Ok(())
     }
 
+    /// Reset all step results for a job to Pending, clearing exit_code, duration_ms, error, started_at, completed_at.
+    pub fn reset_step_results_for_job(&self, job_id: &str) -> Result<u32> {
+        let rows_affected = self
+            .conn
+            .execute(
+                "UPDATE step_results SET status = 'pending', exit_code = NULL, duration_ms = NULL, error = NULL, started_at = NULL, completed_at = NULL
+                 WHERE job_id = ?1",
+                [job_id],
+            )
+            .map_err(|e| {
+                AirlockError::Database(format!(
+                    "Failed to reset step results for job: {e}"
+                ))
+            })?;
+
+        tracing::debug!("Reset {} step results for job: {}", rows_affected, job_id);
+        Ok(rows_affected as u32)
+    }
+
     /// Delete all step results for a run.
     pub fn delete_step_results_for_run(&self, run_id: &str) -> Result<u32> {
         let rows_affected = self

--- a/crates/airlock-daemon/src/handlers/mod.rs
+++ b/crates/airlock-daemon/src/handlers/mod.rs
@@ -108,6 +108,7 @@ pub async fn dispatch(ctx: Arc<HandlerContext>, request: Request) -> Response {
         methods::GET_REPOS => status::handle_get_repos(ctx, id).await,
         methods::REPROCESS_RUN => runs::handle_reprocess_run(ctx, request.params, id).await,
         methods::CANCEL_RUN => runs::handle_cancel_run(ctx, request.params, id).await,
+        methods::RETRY_JOB => runs::handle_retry_job(ctx, request.params, id).await,
         methods::GET_CONFIG => config::handle_get_config(ctx, request.params, id).await,
         methods::UPDATE_CONFIG => config::handle_update_config(ctx, request.params, id).await,
         // Step-based pipeline handlers

--- a/crates/airlock-daemon/src/handlers/runs.rs
+++ b/crates/airlock-daemon/src/handlers/runs.rs
@@ -2,17 +2,22 @@
 //!
 //! Handles run listing, detail retrieval, and reprocessing.
 
-use super::pipeline::execute_pipeline;
+use super::pipeline::{
+    emit_run_final_status, execute_pipeline, execute_single_job, extract_branch_name,
+    load_workflows_for_run, resolve_job_worktree, resume_dag_after_job_completion,
+};
 use super::util::{load_artifacts, parse_params};
 use super::HandlerContext;
 use crate::ipc::{
     error_codes, CancelRunParams, CancelRunResult, GetRunDetailParams, GetRunDetailResult,
     GetRunsParams, GetRunsResult, JobResultInfo, RefUpdateParam, ReprocessRunParams,
-    ReprocessRunResult, Response, RunDetailInfo, RunInfo, StepResultInfo,
+    ReprocessRunResult, Response, RetryJobParams, RetryJobResult, RunDetailInfo, RunInfo,
+    StepResultInfo,
 };
-use airlock_core::step_status_to_string;
+use airlock_core::{step_status_to_string, JobStatus, WorkflowConfig};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 /// Handle the `get_runs` method.
 pub async fn handle_get_runs(
@@ -425,4 +430,438 @@ pub async fn handle_cancel_run(
     };
 
     Response::success(id, serde_json::to_value(result).unwrap())
+}
+
+/// Collect transitive downstream dependents of a job in a workflow DAG.
+///
+/// BFS from the target job: for each job in the workflow, if any of its `needs`
+/// entries is in the frontier, it is a downstream dependent.
+pub fn collect_downstream(target: &str, workflow: &WorkflowConfig) -> Vec<String> {
+    let mut downstream = HashSet::new();
+    let mut queue = VecDeque::new();
+    queue.push_back(target.to_string());
+
+    while let Some(current) = queue.pop_front() {
+        for (job_key, job_config) in workflow.jobs.iter() {
+            if downstream.contains(job_key.as_str()) {
+                continue;
+            }
+            if job_key == target {
+                continue;
+            }
+            if job_config.needs.iter().any(|dep| dep == &current) {
+                downstream.insert(job_key.clone());
+                queue.push_back(job_key.clone());
+            }
+        }
+    }
+
+    downstream.into_iter().collect()
+}
+
+/// Handle the `retry_job` method.
+///
+/// Retries a specific failed/skipped job by resetting it and its transitive
+/// downstream dependents to Pending, then re-executing from that job.
+pub async fn handle_retry_job(
+    ctx: Arc<HandlerContext>,
+    params: serde_json::Value,
+    id: serde_json::Value,
+) -> Response {
+    let params: RetryJobParams = match parse_params(params, &id) {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+
+    // Phase 1: DB reads + validation (hold lock briefly)
+    let (run, repo) = {
+        let db = ctx.db.lock().await;
+
+        let run = match db.get_run(&params.run_id) {
+            Ok(Some(r)) => r,
+            Ok(None) => {
+                return Response::error(
+                    id,
+                    error_codes::RUN_NOT_FOUND,
+                    format!("Run not found: {}", params.run_id),
+                )
+            }
+            Err(e) => {
+                return Response::error(
+                    id,
+                    error_codes::DATABASE_ERROR,
+                    format!("Failed to query database: {e}"),
+                )
+            }
+        };
+
+        let jobs = match db.get_job_results_for_run(&run.id) {
+            Ok(j) => j,
+            Err(e) => {
+                return Response::error(
+                    id,
+                    error_codes::DATABASE_ERROR,
+                    format!("Failed to get job results: {e}"),
+                )
+            }
+        };
+        if run.is_running_from_jobs(&jobs) {
+            return Response::error(
+                id,
+                error_codes::INVALID_REPO_STATE,
+                "Cannot retry a job while the run is still running".to_string(),
+            );
+        }
+
+        let target_job = match jobs.iter().find(|j| j.job_key == params.job_key) {
+            Some(j) => j,
+            None => {
+                return Response::error(
+                    id,
+                    error_codes::STEP_NOT_FOUND,
+                    format!(
+                        "Job '{}' not found in run {}",
+                        params.job_key, params.run_id
+                    ),
+                )
+            }
+        };
+
+        if target_job.status != JobStatus::Failed && target_job.status != JobStatus::Skipped {
+            return Response::error(
+                id,
+                error_codes::JOB_NOT_RETRYABLE,
+                format!(
+                    "Job '{}' has status '{}' — only failed or skipped jobs can be retried",
+                    params.job_key,
+                    airlock_core::job_status_to_string(target_job.status)
+                ),
+            );
+        }
+
+        let repo = match db.get_repo(&run.repo_id) {
+            Ok(Some(r)) => r,
+            Ok(None) => {
+                return Response::error(
+                    id,
+                    error_codes::REPO_NOT_FOUND,
+                    format!("Repository not found: {}", run.repo_id),
+                )
+            }
+            Err(e) => {
+                return Response::error(
+                    id,
+                    error_codes::DATABASE_ERROR,
+                    format!("Failed to query database: {e}"),
+                )
+            }
+        };
+
+        (run, repo)
+    };
+
+    // Phase 2: Load workflows from filesystem (no DB lock held)
+    let branch = extract_branch_name(&run.ref_updates);
+    let workflows = match load_workflows_for_run(&repo.gate_path, &run.head_sha, branch.as_deref())
+    {
+        Ok(w) => w,
+        Err(e) => {
+            return Response::error(
+                id,
+                error_codes::INTERNAL_ERROR,
+                format!("Failed to load workflows: {e}"),
+            )
+        }
+    };
+
+    let workflow = match workflows
+        .iter()
+        .find(|(_, wf)| wf.jobs.contains_key(&params.job_key))
+    {
+        Some((_, wf)) => wf.clone(),
+        None => {
+            return Response::error(
+                id,
+                error_codes::INTERNAL_ERROR,
+                format!(
+                    "Job '{}' not found in any workflow for this run",
+                    params.job_key
+                ),
+            )
+        }
+    };
+
+    let downstream = collect_downstream(&params.job_key, &workflow);
+    let mut reset_jobs = vec![params.job_key.clone()];
+    reset_jobs.extend(downstream.iter().cloned());
+
+    // Phase 3: Re-check guard + reset under lock (prevents TOCTOU races)
+    let jobs = {
+        let db = ctx.db.lock().await;
+
+        // Re-check that run hasn't become active since we released the lock
+        let fresh_jobs = match db.get_job_results_for_run(&run.id) {
+            Ok(j) => j,
+            Err(e) => {
+                return Response::error(
+                    id,
+                    error_codes::DATABASE_ERROR,
+                    format!("Failed to get job results: {e}"),
+                )
+            }
+        };
+        if run.is_running_from_jobs(&fresh_jobs) {
+            return Response::error(
+                id,
+                error_codes::INVALID_REPO_STATE,
+                "Cannot retry a job while the run is still running".to_string(),
+            );
+        }
+
+        // Re-check that the target job is still Failed/Skipped (another retry
+        // may have already reset it to Pending between phase 1 and now).
+        if let Some(target) = fresh_jobs.iter().find(|j| j.job_key == params.job_key) {
+            if target.status != JobStatus::Failed && target.status != JobStatus::Skipped {
+                return Response::error(
+                    id,
+                    error_codes::JOB_NOT_RETRYABLE,
+                    format!(
+                        "Job '{}' is no longer retryable (status: '{}')",
+                        params.job_key,
+                        airlock_core::job_status_to_string(target.status)
+                    ),
+                );
+            }
+        }
+
+        // Reset target + downstream jobs and their steps.
+        // The target job must reset successfully; downstream failures are non-fatal.
+        for job_key in &reset_jobs {
+            if let Some(job) = fresh_jobs.iter().find(|j| &j.job_key == job_key) {
+                let is_target = job_key == &params.job_key;
+                if let Err(e) = db.reset_job_to_pending(&job.id) {
+                    if is_target {
+                        return Response::error(
+                            id,
+                            error_codes::DATABASE_ERROR,
+                            format!("Failed to reset job '{}': {e}", job_key),
+                        );
+                    }
+                    warn!("Failed to reset downstream job '{}': {}", job_key, e);
+                }
+                if let Err(e) = db.reset_step_results_for_job(&job.id) {
+                    if is_target {
+                        return Response::error(
+                            id,
+                            error_codes::DATABASE_ERROR,
+                            format!("Failed to reset steps for job '{}': {e}", job_key),
+                        );
+                    }
+                    warn!(
+                        "Failed to reset steps for downstream job '{}': {}",
+                        job_key, e
+                    );
+                }
+            }
+        }
+
+        // Only clear run error if no other jobs are still failed (outside the reset set)
+        let other_failures = fresh_jobs
+            .iter()
+            .any(|j| j.status == JobStatus::Failed && !reset_jobs.contains(&j.job_key));
+        if !other_failures {
+            if let Err(e) = db.update_run_error(&params.run_id, None) {
+                warn!("Failed to clear run error: {}", e);
+            }
+        }
+
+        fresh_jobs
+    };
+
+    info!(
+        "Retrying job '{}' in run {} (resetting {} jobs: {:?})",
+        params.job_key,
+        run.id,
+        reset_jobs.len(),
+        reset_jobs,
+    );
+
+    // Build job_id_map from fresh_jobs (the authoritative state after reset)
+    let job_id_map: HashMap<String, String> = jobs
+        .iter()
+        .map(|j| (j.job_key.clone(), j.id.clone()))
+        .collect();
+    let job_key = params.job_key.clone();
+    let job_config = match workflow.jobs.get(&job_key) {
+        Some(c) => c.clone(),
+        None => {
+            return Response::error(
+                id,
+                error_codes::INTERNAL_ERROR,
+                format!("Job '{}' no longer found in workflow config", job_key),
+            )
+        }
+    };
+    let run_clone = run.clone();
+    let repo_clone = repo.clone();
+
+    // Spawn background task to execute the retried job.
+    // RunUpdated is emitted after acquiring the permit so the UI doesn't
+    // show "running" while the job is still queued.
+    let downstream_keys: Vec<String> = reset_jobs[1..].to_vec();
+    tokio::spawn(async move {
+        let ref_names: Vec<String> = run_clone
+            .ref_updates
+            .iter()
+            .map(|u| u.ref_name.clone())
+            .collect();
+        let permit = ctx.run_queue.acquire(&run_clone.repo_id, &ref_names).await;
+
+        ctx.emit(crate::ipc::AirlockEvent::RunUpdated {
+            repo_id: run_clone.repo_id.clone(),
+            run_id: run_clone.id.clone(),
+            status: "running".to_string(),
+        });
+
+        // Resolve worktree and execute
+        let (worktree_path, _lease) = match resolve_job_worktree(
+            &ctx,
+            &job_key,
+            &run_clone,
+            &repo_clone,
+            &job_id_map,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                error!(
+                    "Failed to resolve worktree for retry of '{}': {}",
+                    job_key, e
+                );
+                // Mark target job as failed
+                let db = ctx.db.lock().await;
+                if let Some(job_id) = job_id_map.get(&job_key) {
+                    let _ = db.update_job_status(
+                        job_id,
+                        JobStatus::Failed,
+                        None,
+                        None,
+                        Some(&format!("Worktree setup failed: {e}")),
+                    );
+                }
+                // Mark downstream jobs as skipped so the run reaches a final state
+                for ds_key in &downstream_keys {
+                    if let Some(job_id) = job_id_map.get(ds_key.as_str()) {
+                        let _ = db.update_job_status(job_id, JobStatus::Skipped, None, None, None);
+                    }
+                }
+                drop(db);
+                emit_run_final_status(&ctx, &run_clone).await;
+                drop(permit);
+                return;
+            }
+        };
+
+        // Use the permit's cancellation token so a newer push can cancel this retry
+        let status = execute_single_job(
+            &ctx,
+            &run_clone,
+            &repo_clone,
+            &job_key,
+            &job_config,
+            &job_id_map,
+            &worktree_path,
+            &permit.token,
+        )
+        .await;
+
+        // Let the DAG machinery handle downstream jobs
+        resume_dag_after_job_completion(&ctx, &run_clone, &repo_clone, &workflow, &job_key, status)
+            .await;
+        emit_run_final_status(&ctx, &run_clone).await;
+        drop(permit);
+    });
+
+    let result = RetryJobResult {
+        run_id: params.run_id,
+        job_key: params.job_key,
+        success: true,
+        reset_jobs,
+    };
+
+    Response::success(id, serde_json::to_value(result).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use airlock_core::WorkflowConfig;
+
+    fn make_workflow(yaml: &str) -> WorkflowConfig {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn test_collect_downstream_linear() {
+        // A -> B -> C
+        let wf = make_workflow(
+            "jobs:
+  a:
+    steps: []
+  b:
+    needs: a
+    steps: []
+  c:
+    needs: b
+    steps: []",
+        );
+        let mut result = collect_downstream("a", &wf);
+        result.sort();
+        assert_eq!(result, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn test_collect_downstream_diamond() {
+        // A -> {B, C} -> D
+        let wf = make_workflow(
+            "jobs:
+  a:
+    steps: []
+  b:
+    needs: a
+    steps: []
+  c:
+    needs: a
+    steps: []
+  d:
+    needs: [b, c]
+    steps: []",
+        );
+
+        let mut result = collect_downstream("a", &wf);
+        result.sort();
+        assert_eq!(result, vec!["b", "c", "d"]);
+
+        // Retrying B only collects D
+        let result = collect_downstream("b", &wf);
+        assert_eq!(result, vec!["d"]);
+    }
+
+    #[test]
+    fn test_collect_downstream_no_deps() {
+        // A -> B, C (leaf)
+        let wf = make_workflow(
+            "jobs:
+  a:
+    steps: []
+  b:
+    needs: a
+    steps: []
+  c:
+    steps: []",
+        );
+        let result = collect_downstream("c", &wf);
+        assert!(result.is_empty());
+    }
 }

--- a/crates/airlock-daemon/src/ipc.rs
+++ b/crates/airlock-daemon/src/ipc.rs
@@ -103,6 +103,7 @@ pub mod error_codes {
     pub const GIT_ERROR: i32 = -32020;
     pub const DATABASE_ERROR: i32 = -32021;
     pub const STEP_NOT_FOUND: i32 = -32024;
+    pub const JOB_NOT_RETRYABLE: i32 = -32025;
 }
 
 /// IPC method names.
@@ -132,6 +133,7 @@ pub mod methods {
     pub const GET_RUN_DIFF: &str = "get_run_diff";
     pub const APPLY_PATCHES: &str = "apply_patches";
     pub const CANCEL_RUN: &str = "cancel_run";
+    pub const RETRY_JOB: &str = "retry_job";
 }
 
 // =============================================================================
@@ -248,6 +250,13 @@ pub struct ApplyPatchesParams {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CancelRunParams {
     pub run_id: String,
+}
+
+/// Parameters for the `retry_job` method.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RetryJobParams {
+    pub run_id: String,
+    pub job_key: String,
 }
 
 /// Parameters for the `get_config` method.
@@ -467,6 +476,17 @@ pub struct ReprocessRunResult {
 pub struct CancelRunResult {
     pub run_id: String,
     pub success: bool,
+}
+
+/// Result for the `retry_job` method.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RetryJobResult {
+    pub run_id: String,
+    pub job_key: String,
+    pub success: bool,
+    /// Job keys that were reset (target + downstream dependents).
+    #[serde(default)]
+    pub reset_jobs: Vec<String>,
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes #83 

Adds the ability to retry individual failed or skipped jobs within a pipeline run. The feature spans the full stack — from a new daemon IPC handler that resets the target job and its transitive downstream dependents, through the Tauri bridge, to retry buttons in the desktop app's sidebar UI.

**Risk Assessment:** 🟡 Medium — Well-structured new IPC method with good TOCTOU protection, but silent error swallowing in UI and stale run-status window are worth addressing as follow-ups.

## Architecture

```mermaid
flowchart TD
    run_detail["RunDetail page (updated)"]
    activity_tab["ActivityTab (updated)"]
    stages_sidebar["StagesSidebar (updated)"]
    use_daemon["retryJob hook (added)"]
    tauri_mock["mockInvoke retry_job (added)"]
    tauri_cmd["retry_job Tauri command (added)"]
    ipc_client["IpcClient::retry_job (added)"]

    subgraph daemon_layer["Daemon"]
        direction TB
        dispatch["dispatch (updated)"]
        handler["handle_retry_job (added)"]
        collect_downstream_fn["collect_downstream (added)"]
        ipc_types["RetryJobParams / RetryJobResult (added)"]
        handler --> collect_downstream_fn
        handler --> ipc_types
        dispatch --> handler
    end

    subgraph pipeline_layer["Pipeline Execution"]
        direction TB
        execute_single_job["execute_single_job (unchanged)"]
        resume_dag["resume_dag_after_job_completion (unchanged)"]
        resolve_worktree["resolve_job_worktree (unchanged)"]
        emit_final["emit_run_final_status (unchanged)"]
    end

    subgraph core_db["Core DB"]
        direction TB
        reset_job["reset_job_to_pending (added)"]
        reset_steps["reset_step_results_for_job (added)"]
    end

    run_detail -->|"passes onRetryJob"| activity_tab
    activity_tab -->|"passes onRetryJob"| stages_sidebar
    run_detail -->|"calls"| use_daemon
    use_daemon -->|"invokes"| tauri_cmd
    tauri_cmd -->|"sends IPC"| ipc_client
    ipc_client -->|"routes to"| dispatch
    handler -->|"resets state"| reset_job
    handler -->|"resets state"| reset_steps
    handler -->|"spawns execution"| execute_single_job
    handler -->|"resumes DAG"| resume_dag
    handler -->|"resolves worktree"| resolve_worktree
    handler -->|"emits final status"| emit_final
```

## Key changes made

- **Daemon handler (`handle_retry_job`)**: New IPC method that validates the job is retryable (failed/skipped, run not active), computes transitive downstream dependents via BFS (`collect_downstream`), resets all affected jobs/steps to Pending in the DB, then spawns a background task to re-execute the job through the existing pipeline machinery (`execute_single_job` + `resume_dag_after_job_completion`). Includes TOCTOU protection by re-checking state under lock before resetting.
- **IPC types**: New `RetryJobParams`, `RetryJobResult`, `JOB_NOT_RETRYABLE` error code, and `retry_job` method constant.
- **Core DB methods**: `reset_job_to_pending` and `reset_step_results_for_job` to clear job/step state back to Pending.
- **Tauri bridge**: New `retry_job` command wired through `IpcClient` to the daemon.
- **Frontend UI**: Retry buttons (refresh icon with spinner) added to `StagesSidebar` for failed/skipped jobs, wired through `ActivityTab` to `RunDetail` page handler. Includes mock support for dev mode.
- **Tests**: Unit tests for `collect_downstream` covering linear chains, diamond DAGs, and leaf nodes with no dependents.

## How was this tested

- Unit tests for `collect_downstream` covering linear chains, diamond DAGs, and leaf nodes with no dependents
- Integration tests verifying the full retry flow through the daemon IPC handler