### PR TITLE
fix(app): reduce event-driven refetch storm

### DIFF
--- a/crates/airlock-app/src/hooks/use-airlock-events.ts
+++ b/crates/airlock-app/src/hooks/use-airlock-events.ts
@@ -145,7 +145,7 @@ export interface RefreshOnEventsOptions {
   stepName?: string | null;
   /** Event types to listen for (defaults to all refresh-worthy events) */
   events?: string[];
-  /** Debounce time in ms (default: 100) */
+  /** Debounce time in ms (default: 500) */
   debounceMs?: number;
 }
 
@@ -179,7 +179,7 @@ export function useRefreshOnEvents(refresh: () => void, options: RefreshOnEvents
       AIRLOCK_EVENTS.JOB_COMPLETED,
       AIRLOCK_EVENTS.STEP_COMPLETED,
     ],
-    debounceMs = 100,
+    debounceMs = 500,
   } = options;
 
   const refreshRef = useRef(refresh);

--- a/crates/airlock-app/src/hooks/use-daemon.ts
+++ b/crates/airlock-app/src/hooks/use-daemon.ts
@@ -234,7 +234,7 @@ export function useRuns(repoId: string | null, limit?: number) {
     initialLoading: false,
   });
 
-  // Auto-refresh on run and job events so derived status stays current
+  // Auto-refresh on run-level events only (daemon emits RunUpdated on job transitions)
   useRefreshOnEvents(refresh, {
     repoId,
     events: [
@@ -242,10 +242,6 @@ export function useRuns(repoId: string | null, limit?: number) {
       AIRLOCK_EVENTS.RUN_UPDATED,
       AIRLOCK_EVENTS.RUN_COMPLETED,
       AIRLOCK_EVENTS.RUN_SUPERSEDED,
-      AIRLOCK_EVENTS.JOB_STARTED,
-      AIRLOCK_EVENTS.JOB_COMPLETED,
-      AIRLOCK_EVENTS.STEP_STARTED,
-      AIRLOCK_EVENTS.STEP_COMPLETED,
     ],
   });
 
@@ -539,17 +535,13 @@ export function useAllRuns(limit?: number) {
 
   const { data: runs, error, loading, refresh } = useDaemonQuery<(RunInfo & { repo_name: string })[]>(fetcher, []);
 
-  // Auto-refresh on run, job, and step events so derived status (executing/awaiting counts) stays current
+  // Auto-refresh on run-level events only (daemon emits RunUpdated on job transitions)
   useRefreshOnEvents(refresh, {
     events: [
       AIRLOCK_EVENTS.RUN_CREATED,
       AIRLOCK_EVENTS.RUN_UPDATED,
       AIRLOCK_EVENTS.RUN_COMPLETED,
       AIRLOCK_EVENTS.RUN_SUPERSEDED,
-      AIRLOCK_EVENTS.JOB_STARTED,
-      AIRLOCK_EVENTS.JOB_COMPLETED,
-      AIRLOCK_EVENTS.STEP_STARTED,
-      AIRLOCK_EVENTS.STEP_COMPLETED,
     ],
   });
 

--- a/crates/airlock-daemon/src/handlers/pipeline.rs
+++ b/crates/airlock-daemon/src/handlers/pipeline.rs
@@ -608,6 +608,11 @@ pub(super) async fn skip_job(
         job_key: job_key.to_string(),
         status: "skipped".to_string(),
     });
+    ctx.emit(AirlockEvent::RunUpdated {
+        repo_id: run.repo_id.clone(),
+        run_id: run.id.clone(),
+        status: "updated".to_string(),
+    });
 
     job_statuses.insert(job_key.to_string(), JobStatus::Skipped);
 }
@@ -639,6 +644,11 @@ pub(super) async fn fail_job_worktree(
         run_id: run.id.clone(),
         job_key: job_key.to_string(),
         status: "failed".to_string(),
+    });
+    ctx.emit(AirlockEvent::RunUpdated {
+        repo_id: run.repo_id.clone(),
+        run_id: run.id.clone(),
+        status: "updated".to_string(),
     });
 
     job_statuses.insert(job_key.to_string(), JobStatus::Failed);
@@ -1056,6 +1066,11 @@ pub(super) async fn execute_single_job(
         run_id: run.id.clone(),
         job_key: job_key.to_string(),
     });
+    ctx.emit(AirlockEvent::RunUpdated {
+        repo_id: run.repo_id.clone(),
+        run_id: run.id.clone(),
+        status: "updated".to_string(),
+    });
 
     // Ensure worktree exists
     if !worktree_path.exists() {
@@ -1076,6 +1091,11 @@ pub(super) async fn execute_single_job(
                 run_id: run.id.clone(),
                 job_key: job_key.to_string(),
                 status: "failed".to_string(),
+            });
+            ctx.emit(AirlockEvent::RunUpdated {
+                repo_id: run.repo_id.clone(),
+                run_id: run.id.clone(),
+                status: "updated".to_string(),
             });
             return JobStatus::Failed;
         }
@@ -1167,6 +1187,11 @@ pub(super) async fn execute_single_job(
         run_id: run.id.clone(),
         job_key: job_key.to_string(),
         status: status_str.to_string(),
+    });
+    ctx.emit(AirlockEvent::RunUpdated {
+        repo_id: run.repo_id.clone(),
+        run_id: run.id.clone(),
+        status: "updated".to_string(),
     });
 
     info!("Job '{}' completed with status: {}", job_key, status_str);

--- a/crates/airlock-daemon/src/handlers/steps.rs
+++ b/crates/airlock-daemon/src/handlers/steps.rs
@@ -343,6 +343,11 @@ async fn resume_pipeline_after_approval(
             job_key: approved_job_key.to_string(),
             status: "passed".to_string(),
         });
+        ctx.emit(AirlockEvent::RunUpdated {
+            repo_id: run.repo_id.clone(),
+            run_id: run.id.clone(),
+            status: "updated".to_string(),
+        });
 
         // Resume DAG: check if dependent jobs can now start
         resume_dag_after_job_completion(&ctx, &run, &repo, &workflow, approved_job_key, job_status)
@@ -452,6 +457,11 @@ async fn resume_pipeline_after_approval(
             run_id: run.id.clone(),
             job_key: approved_job_key.to_string(),
             status: status_str.to_string(),
+        });
+        ctx.emit(AirlockEvent::RunUpdated {
+            repo_id: run.repo_id.clone(),
+            run_id: run.id.clone(),
+            status: "updated".to_string(),
         });
 
         // Resume DAG: check if dependent jobs can now start


### PR DESCRIPTION
## Summary

The desktop app was experiencing lag due to an event-driven refetch storm. When pipeline jobs and steps transitioned states, the frontend was listening to fine-grained events (`JOB_STARTED`, `JOB_COMPLETED`, `STEP_STARTED`, `STEP_COMPLETED`) in addition to run-level events, causing a cascade of redundant data refetches. The fix takes a two-pronged approach: the daemon now emits a coarser `RunUpdated` event on every job transition, and the frontend stops listening to job/step-level events for run lists — relying solely on run-level events with an increased debounce window.

**Risk Assessment:** 🟢 Low — Well-scoped performance fix that coalesces granular job/step events into run-level events to reduce frontend refetch storms.

## Architecture

```mermaid
flowchart TD
    subgraph daemon["Daemon (Rust)"]
        direction TB
        pipeline["pipeline.rs (updated)"]
        steps["steps.rs (updated)"]
        run_updated_event["RunUpdated Event (added)"]
        pipeline -- "emits on job transitions" --> run_updated_event
        steps -- "emits on step approval" --> run_updated_event
    end

    subgraph frontend["Desktop App (React)"]
        direction TB
        use_events["useRefreshOnEvents (updated)"]
        use_runs["useRuns hook (updated)"]
        use_all_runs["useAllRuns hook (updated)"]
        use_runs -- "subscribes to run-level events only" --> use_events
        use_all_runs -- "subscribes to run-level events only" --> use_events
    end

    run_updated_event -- "received by frontend" --> use_events
    use_events -- "debounced refetch (500ms)" --> use_runs
    use_events -- "debounced refetch (500ms)" --> use_all_runs
```

## Key changes

- **Daemon (`pipeline.rs`, `steps.rs`)**: Added `RunUpdated` event emissions alongside every `JobStarted`, `JobCompleted`, and `JobSkipped` event. This ensures the frontend can track run-level state changes without subscribing to granular job/step events.
- **Frontend (`use-daemon.ts`)**: Removed `JOB_STARTED`, `JOB_COMPLETED`, `STEP_STARTED`, and `STEP_COMPLETED` from the event subscriptions in `useRuns` and `useAllRuns` hooks, reducing the number of refetch triggers significantly.
- **Frontend (`use-airlock-events.ts`)**: Increased the default debounce interval from 100ms to 500ms, coalescing rapid event bursts into fewer refetch calls.

## How was this tested

- All existing tests pass
- Verified that run list updates correctly with only run-level events
- Confirmed reduced refetch frequency during pipeline execution